### PR TITLE
Terminology and other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,4 @@
----
-lang: en
-...
-
 # did:btc1 DID Method Specification
-
-### Authors: {.unnumbered .unlisted}
-
-- Ryan Grant <rgrant@contract.design> [Digital Contract Design](https://contract.design/)
-- Will Abramson <will@legreq.com> [Legendary Requirements](https://legreq.com/)
-- Joe Andrieu <joe@legreq.com> [Legendary Requirements](https://legreq.com/)
-- Kevin Dean <kevin@legreq.com> [Legendary Requirements](https://legreq.com/)
-- Dan Pape <dpape@contract.design> [Digital Contract Design](https://contract.design/)
-- Jennie Meier <jennie@contract.design> [Digital Contract Design](https://contract.design/)
-
-### Contributors: {.unnumbered .unlisted}
-
-- Kate Sills <katelynsills@gmail.com>
-
-### Publication Date: 20th September 2024 {.unnumbered .unlisted}
-
-### Copyright &copy; 2024 Digital Contract Design {.unnumbered .unlisted}
-
-### Licence Statement: TODO {.unnumbered .unlisted}
-
-## Abstract {.unnumbered .unlisted}
 
 **did:btc1** is a censorship resistant DID Method using the Bitcoin blockchain
 as a Verifiable Data Registry to announce changes to the DID document.

--- a/chapters/CRUD-Operations.md
+++ b/chapters/CRUD-Operations.md
@@ -49,7 +49,7 @@ the type SingletonBeacon.
 1. Set `initialDocument` to a copy of the `intermediateDocument`.
 1. Replace all `did:btc1:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
    values in the `initialDocument` with the `did`.
-1.  Optionally store `canonicalBytes` on a Content Addressable Storage (CAS)
+1.  Optionally store `canonicalBytes` on a ::Content Addressable Storage:: (CAS)
     system like IPFS. If doing so, implementations MUST use CIDs generated following
     the IPFS v1 algorithm.
 1. Return `did` and `initialDocument`.
@@ -76,7 +76,7 @@ intermediate DID document.
 ### Read
 
 The read operation is executed by a resolver after a resolution request identifying
-a specific **did:btc1** `identifier` is received from a client at Resolution Time.
+a specific **did:btc1** `identifier` is received from a client at ::Resolution Time::.
 The request MAY contain a `resolutionOptions` object containing additional information
 to be used in resolution. The resolver then attempts to resolve the DID document
 of the `identifier` at a specific Target Time. The Target Time is either provided
@@ -222,7 +222,7 @@ Each Beacon is of the type SingletonBeacon. The algorithm returns a `services` a
 
 This algorithm creates a Beacon service that can be included into the services
 array of a DID document.
-The algorithm takes in a `serviceId`, a Beacon Type, `beaconType`, and a
+The algorithm takes in a `serviceId`, a ::Beacon Type:: `beaconType`, and a
 `bitcoinAddress`. It returns a `service` object.
 
 1. Initialize a `beacon` variable to an empty object.
@@ -235,9 +235,9 @@ The algorithm takes in a `serviceId`, a Beacon Type, `beaconType`, and a
 ##### External Resolution
 
 This algorithm externally retrieves an `intermediateDocumentRepresentation`,
-either by retrieving it from Content Addressable Storage (CAS) or from the Sidecar
-data provided as part of the resolution request. The algorithm takes in a
-**did:btc1** `identifier`, a `identifierComponents` object and a
+either by retrieving it from ::Content Addressable Storage:: (CAS) or from the
+::Sidecar:: data provided as part of the resolution request. The algorithm
+takes in a **did:btc1** `identifier`, a `identifierComponents` object and a
 `resolutionOptions` object.
 It returns an `initialDocument`, which is a conformant DID document validated
 against the `identifier`.
@@ -273,13 +273,13 @@ otherwise it throws an error.
 
 This algorithm attempts to retrieve an `initialDocument` from a Content
 Addressable Storage (CAS) system by converting the bytes in the `identifier`
-into a Content Identifier (CID). The algorithm takes in an `identifier` and an
+into a ::Content Identifier:: (CID). The algorithm takes in an `identifier` and an
 `identifierComponents` object and returns an `initialDocument`.
 
 1. Set `hashBytes` to `identifierComponents.genesisBytes`.
 1. Set `cid` to the result of converting `hashBytes` to a IPFS v1 CID.
 1. Set `intermediateDocumentRepresentation` to the result of fetching the `cid`
-   against a Content Addressable Storage (CAS) system such as IPFS.
+   against a ::Content Addressable Storage:: (CAS) system such as IPFS.
 1. Set `initialDocument` to the copy of the `intermediateDocumentRepresentation`.
 1. Replace the string
    (`did:btc1:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`) with
@@ -289,7 +289,7 @@ into a Content Identifier (CID). The algorithm takes in an `identifier` and an
 #### Resolve Target Document
 
 This algorithm resolves a DID document from an initial document by walking the
-Bitcoin blockchain to identify Beacon Signals that announce DID Update Payloads
+Bitcoin blockchain to identify ::Beacon Signals:: that announce ::DID Update Payloads::
 applicable to the **did:btc1** identifier being resolved. The algorithm takes
 in an `initialDocument` and a set of `resolutionOptions`. The algorithm returns
 a valid `targetDocument` or throws an error.
@@ -387,7 +387,7 @@ The algorithm returns a DID document.
 ##### Find Next Signals
 
 This algorithm takes in a `contemporaryBlockheight` and a set of `beacons` and
-finds the next Bitcoin block containing Beacon Signals from one or more of the
+finds the next Bitcoin block containing ::Beacon Signals:: from one or more of the
 `beacons`.
 
 This algorithm takes as inputs a Bitcoin blockheight specified by
@@ -439,13 +439,13 @@ to process the Beacon Signals.
        structure of sidecarData
     1. Set `didUpdatePayload` to the result of passing `signalTx` and
        `signalSidecarData` to the Process Beacon Signal algorithm defined by the
-       corresponding Beacon `type`. See [Update Beacons].
+       corresponding ::Beacon Type::. See [Update Beacons].
     1. If `didUpdatePayload` is not null, push `didUpdatePayload` to `updates`.
 1. Return `updates`.
 
 ##### Confirm Duplicate Update
 
-This algorithm takes in a DID Update Payload and verifies that the update is a
+This algorithm takes in a ::DID Update Payload:: and verifies that the update is a
 duplicate against the hash history of previously applied updates.
 The algorithm takes in an `update` and an array of hashes, `updateHashHistory`.
 It throws an error if the `update` is not a duplicate, otherwise it returns.
@@ -530,7 +530,7 @@ three Beacon Types: `SingletonBeacon`, `CIDAggregateBeacon`, and
 This algorithm takes in a `btc1Identifier`, `sourceDocument`, `sourceVersionId`,
 and `documentPatch` objects. It applies the `documentPatch` to the `sourceDocument`
 and verifies the resulting `targetDocument` is a conformant DID document. Then
-it constructs and returns an unsigned DID Update Payload.
+it constructs and returns an unsigned ::DID Update Payload::.
 
 1. Check that `sourceDocument.id` equals `btc1Identifier` else MUST raise
    `invalidDIDUpdate` error.
@@ -562,7 +562,7 @@ This algorithm takes in a `btc1Identifier`, an unsigned `didUpdatePayload`, and 
 Integrity proof following the Authorization Capabilities (ZCAP-LD) and
 VC Data Integrity specifications.
 
-The algorithm returns the invoked DID Update Payload.
+The algorithm returns the invoked ::DID Update Payload::.
 
 1. Set `privateKeyBytes` to the result of retrieving the private key bytes
    associated with the `verificationMethod` value. How this is achieved is left to
@@ -685,7 +685,7 @@ This algorithm takes in a `sourceDocument`, an array of `beaconIds`, and a
 `didUpdateInvocation`. It retrieves `beaconServices` from the `sourceDocument`
 and calls the [Broadcast DID Update Attestation] algorithm corresponding the type of
 the Beacon. The algorithm returns an array of `signalsMetadata`, containing the
-necessary data to validate the Beacon Signal against the `didUpdateInvocation`.
+necessary data to validate the ::Beacon Signal:: against the `didUpdateInvocation`.
 
 1. Set `beaconServices` to an empty array.
 1. Set `signalMetadata` to an empty array.

--- a/chapters/Index.md
+++ b/chapters/Index.md
@@ -8,16 +8,25 @@ lang: en
 
 ### Authors: {.unnumbered .unlisted}
 
-- Ryan Grant <rgrant@contract.design> [Digital Contract Design](https://contract.design/)
-- Will Abramson <will@legreq.com> [Legendary Requirements](https://legreq.com/)
-- Joe Andrieu <joe@legreq.com> [Legendary Requirements](https://legreq.com/)
-- Kevin Dean <kevin@legreq.com> [Legendary Requirements](https://legreq.com/)
-- Dan Pape <dpape@contract.design> [Digital Contract Design](https://contract.design/)
-- Jennie Meier <jennie@contract.design> [Digital Contract Design](https://contract.design/)
++---------------+--------------------------+-----------------------------------------------------+
+| Ryan Grant    | <rgrant@contract.design> | [Digital Contract Design](https://contract.design/) |
++---------------+--------------------------+-----------------------------------------------------+
+| Will Abramson | <will@legreq.com>        | [Legendary Requirements](https://legreq.com/)       |
++---------------+--------------------------+-----------------------------------------------------+
+| Joe Andrieu   | <joe@legreq.com>         | [Legendary Requirements](https://legreq.com/)       |
++---------------+--------------------------+-----------------------------------------------------+
+| Kevin Dean    | <kevin@legreq.com>       | [Legendary Requirements](https://legreq.com/)       |
++---------------+--------------------------+-----------------------------------------------------+
+| Dan Pape      | <dpape@contract.design>  | [Digital Contract Design](https://contract.design/) |
++---------------+--------------------------+-----------------------------------------------------+
+| Jennie Meier  | <jennie@contract.design> | [Digital Contract Design](https://contract.design/) |
++---------------+--------------------------+-----------------------------------------------------+
 
 ### Contributors: {.unnumbered .unlisted}
 
-- Kate Sills <katelynsills@gmail.com>
++---------------+--------------------------+
+| Kate Sills    | <katelynsills@gmail.com> |
++---------------+--------------------------+
 
 ### Publication Date: 20th September 2024 {.unnumbered .unlisted}
 

--- a/chapters/Index.md
+++ b/chapters/Index.md
@@ -1,0 +1,35 @@
+---
+lang: en
+...
+
+# did:btc1 DID Method Specification
+
+## did:btc1 DID Method Specification
+
+### Authors: {.unnumbered .unlisted}
+
+- Ryan Grant <rgrant@contract.design> [Digital Contract Design](https://contract.design/)
+- Will Abramson <will@legreq.com> [Legendary Requirements](https://legreq.com/)
+- Joe Andrieu <joe@legreq.com> [Legendary Requirements](https://legreq.com/)
+- Kevin Dean <kevin@legreq.com> [Legendary Requirements](https://legreq.com/)
+- Dan Pape <dpape@contract.design> [Digital Contract Design](https://contract.design/)
+- Jennie Meier <jennie@contract.design> [Digital Contract Design](https://contract.design/)
+
+### Contributors: {.unnumbered .unlisted}
+
+- Kate Sills <katelynsills@gmail.com>
+
+### Publication Date: 20th September 2024 {.unnumbered .unlisted}
+
+### Copyright &copy; 2024 Digital Contract Design {.unnumbered .unlisted}
+
+### Licence Statement: TODO {.unnumbered .unlisted}
+
+### Abstract {.unnumbered .unlisted}
+
+**did:btc1** is a censorship resistant DID Method using the Bitcoin blockchain
+as a Verifiable Data Registry to announce changes to the DID document.
+It improves on prior work by allowing: zero-cost off-chain DID creation;
+aggregated updates for scalable on-chain update costs; long-term identifiers
+that can support frequent updates; private communication of the DID document;
+private DID resolution; and non-repudiation appropriate for serious contracts.

--- a/chapters/Introduction-and-Motivation.md
+++ b/chapters/Introduction-and-Motivation.md
@@ -22,7 +22,7 @@ documents leak every time the DID is used then these DIDs do not accomplish
 much, either.DIDs that are shared with a relying party can be seen by not only
 that party but also by any third party resolver that the relying party contracts
 with. The next step in trust-minimization is a DID document transferred directly
-from the DID controller to the relying party.We call this transfer "Sidecar"
+from the DID controller to the relying party.We call this transfer "::Sidecar::"
 delivery.When a relying party *who is willing to cooperate with privacy concerns*
 has the capacity to act as their own resolver, then privacy has a chance.
 
@@ -32,7 +32,8 @@ history. Bitcoin's blockchain is the premiere global database for immutably
 anchoring information to a specific time. This DID Method takes care to only
 allow resolution to succeed when the resolver can clearly state that all data is
 available to present only one canonical history for a DID. This is a necessary
-feature when key material is used to sign serious contracts. We call this feature "Non-Repudiation", and point out how an anti-feature called "Late Publishing"
+feature when key material is used to sign serious contracts. We call this feature
+"::Non-Repudiation::", and point out how an anti-feature called "::Late Publishing::"
 affects some other DID Methods.
 
 **did:btc1** is created for those who wish to have it all:
@@ -70,7 +71,7 @@ resistance. It has the following limitations:
 ION anchors on the Bitcoin blockchain following a Sidetree approach. It has the
 following limitations:
 * Although in the normal case where data is available this DID Method performs
-  fine, it does not fully address the Late Publishing problem, and thus attackers
+  fine, it does not fully address the ::Late Publishing:: problem, and thus attackers
   may manipulate edge cases to create doubt about signatures used for attestation.
 * It stores DID documents on IPFS, and thus does not allow keeping the DID document
   private between the DID controller and a relying party, even if they are capable of
@@ -102,12 +103,12 @@ provide. In summary its main limitations are:
 * Offline creation allows creating DIDs without any on-chain transactions.
 * Aggregator Beacons can aggregate any number of updates from any number of DID
   controllers in one Bitcoin transaction.
-* Non-repudiation is provided by - and *"Late Publishing"* is avoided by - ensuring
+* ::Non-repudiation:: is provided by - and *"::Late Publishing::"* is avoided by - ensuring
   100% valid coverage of the entire update history without gaps or ambiguity.
-* Public disclosure of DID documents can be avoided by using Sidecar delivery
+* Public disclosure of DID documents can be avoided by using ::Sidecar:: delivery
   of the necessary DID history along with the DID itself.
 * Public disclosure of updates to DID documents can also be avoided by only
-  recording a Sparse Merkle Tree (SMT) of proofs of DID updates on-chain.
+  recording a ::Sparse Merkle Tree:: (SMT) of proofs of DID updates on-chain.
 * Resolvers need only filter transactions likely to contain updates for those
   DIDs of interest.
 * Any kind of key can be included in a DID Document, using an update.

--- a/chapters/Privacy-Considerations.md
+++ b/chapters/Privacy-Considerations.md
@@ -7,7 +7,7 @@
 **did:btc1** was designed such that updates to DID documents are NOT REQUIRED
 to be public. Bitcoin is used to publicly announce and anchor updates to DID
 documents, however the updates themselves can be kept private by DID controllers
-and provided through a Sidecar mechanism at resolution time.
+and provided through a ::Sidecar: mechanism at resolution time.
 
 #### DID Documents Need not be Public
 
@@ -17,8 +17,8 @@ plus a series of updates to that DID document. To keep the DID document fully
 private, the DID controller can choose to use an externally resolved initial
 **did:btc1** and not place the initial DID document on a Content Addressable
 Storage (CAS) system such as IPFS. The initial DID document can be provided
-at resolution time through a Sidecar mechanism along with the collection of
-updates that can be verified against the relevant Beacon Signals for the DID
+at resolution time through a ::Sidecar:: mechanism along with the collection of
+updates that can be verified against the relevant ::Beacon Signals:: for the DID
 being resolved.
 
 #### Offline DID Generation
@@ -31,8 +31,8 @@ and externally resolvable DIDs.
 #### Beacon Coordinators do not Need to View or Validate DID Documents or Document Updates
 
 Beacon coordinators in **did:btc1** are entities that coordinate Aggregator
-Beacons and the corresponding Beacon Signals that announce and anchor an aggregated
-set of DID Update Payloads. However, in **did:btc1,** Aggregators are able to
+Beacons and the corresponding ::Beacon Signals:: that announce and anchor an aggregated
+set of ::DID Update Payloads::. However, in **did:btc1,** Aggregators are able to
 coordinate Beacon Signals without needing to view or validate DID documents or
 the updates. Instead, they are provided with a hash or CID of the update for a
 specific DID which they include in the Beacon Signal according to the type of
@@ -56,23 +56,23 @@ well as maintained to find new ones.
 
 #### Update Payloads Stored in Content Addressable Storage (CAS) Systems are Publicly Accessible
 
-Update payloads stored in Content Addressable Storage (CAS) such as IPFS SHOULD
+Update payloads stored in ::Content Addressable Storage:: (CAS) such as IPFS SHOULD
 be considered public. Anyone MAY retrieve this information (assuming they have
 the CID) and use it to track the DID over time. IPFS node operators would have
 access to all content stored on IPFS and could choose to index certain data like
-DID Update Payloads, including the updates posted by that DID's Beacon. This MAY
+::DID Update Payloads::, including the updates posted by that DID's Beacon. This MAY
 advertise information about the DID that the controller wishes to remain private.
 
 Those parties most concerned about privacy SHOULD maintain their DID Update
-Payloads in a Sidecar manner and provide them to necessary parties during
+Payloads in a ::Sidecar:: manner and provide them to necessary parties during
 resolution. It is RECOMMENDED not to include any sensitive data other than the
 necessary DID update data.
 
 #### Beacon Coordinators Know the DIDs Being Aggregated by a Cohort
 
-Within Sparse Merkle Tree (SMT) Beacons, the DID is used as a path to a leaf
+Within ::Sparse Merkle Tree:: (SMT) Beacons, the DID is used as a path to a leaf
 node in the SMT. The coordinator MUST know these paths for them to be able to
-construct the tree and generate the correct proof paths. Within Content Identifier
+construct the tree and generate the correct proof paths. Within ::Content Identifier::
 (CID) based Beacons, the coordinator MUST construct an aggregated bundle that
 includes all DIDs aggregated as a key to the CID for that DID's Update Payload.
 This means that for both types of Aggregator Beacons, the coordinator necessarily
@@ -81,10 +81,10 @@ MUST know all DIDs being aggregated by a cohort.
 #### CID Aggregation Cohort Members Know All DIDs that are Updated
 
 Cohort members participating in a CID Aggregator Beacon learn all DIDs that are
-updated in each Beacon Signal. This is because they SHOULD verify the contents
+updated in each ::Beacon Signal::. This is because they SHOULD verify the contents
 of the Beacon Signal before authorizing it and a CID Aggregator's Beacon Signal
 contains a CID to an Update Bundle. An Update Bundle is a JSON object mapping
-**did:btc1** identifiers to CID values for individual DID Update Payloads. Each
+**did:btc1** identifiers to CID values for individual ::DID Update Payloads::. Each
 DID controller SHOULD independently retrieve and verify the contents of the
 Update Bundle to ensure it contains the expected update for their DID.
 

--- a/chapters/Security-Considerations.md
+++ b/chapters/Security-Considerations.md
@@ -4,15 +4,15 @@
 
 #### Late Publishing
 
-**did:btc1** was designed to avoid Late Publishing such that, independent of when
+**did:btc1** was designed to avoid ::Late Publishing:: such that, independent of when
 a resolution occurs, the DID document history and provenance is guaranteed to
 be invariant. This is achieved through requiring strict ordering of DID updates
-and complete coverage of all relevant Beacon Signals. Resolvers MUST process all
+and complete coverage of all relevant ::Beacon Signals::. Resolvers MUST process all
 relevant Beacon Signals and enforce strict ordering.
 
 #### Invalidation Attacks
 
-Invalidation attacks are where adversaries are able to publish Beacon Signals
+Invalidation attacks are where adversaries are able to publish ::Beacon Signals::
 that claim to contain updates for DIDs they do not control. Due to the requirement
 for complete coverage, if these updates can not be retrieved by a resolver, the
 DID MUST be considered invalid. To prevent these attacks, all Beacon Signals SHOULD
@@ -30,7 +30,7 @@ Publishing. This means that the updates MUST be available to resolver at the
 time of resolution. It is the responsibility of DID controllers to persist this
 data, otherwise the consequence is that the DID MAY not be resolvable (depending
 on data accessibility from the perspective of the resolver).  DID controllers
-MAY store DID Update Payloads on a Content Addressable Storage (CAS) system. DID
+MAY store ::DID Update Payloads:: on a ::Content Addressable Storage:: (CAS) system. DID
 controllers SHOULD consider that in some constrained environments it is preferable
 to discard a DID and replace it with a newly issued DID, rather than rotating
 a key.
@@ -46,7 +46,7 @@ from the set of cohort keys which the coordinator SHOULD provide.
 
 #### Aggregator Beacon Signal Verification
 
-Beacon Signals from Aggregators that a DID controller is a participant of will
+::Beacon Signals:: from Aggregators that a DID controller is a participant of will
 either announce an update for their DID or will contain no update for their DID.
 The DID controller SHOULD verify that the Beacon Signal announces the update they
 expect (or no update) for all Beacon Signals broadcast by Aggregators before
@@ -56,21 +56,21 @@ the DID to be invalidated.
 
 #### Key Compromise
 
-In **did:btc1**, cryptographic keys authorize both DID updates and Beacon Signals.
+In **did:btc1**, cryptographic keys authorize both DID updates and ::Beacon Signals::.
 Should these keys get compromised without the DID controller's knowledge, it
 would be possible for an adversary to take control of a DID by submitting a DID
 Update Payload to a Beacon that replaces key material and Beacons in the DID
 document for ones under the adversary's control. Such an attack would be detectable
 by the DID controller, as they would see a valid spend from a Beacon that they
-did not authorize. Additionally, if the DID relied on Sidecar data, without access
+did not authorize. Additionally, if the DID relied on ::Sidecar:: data, without access
 to this data the DID would be useless to the adversary as they would be unable
 to demonstrate a valid complete history of the DID during resolution.
 
 #### Cryptographic Compromise
 
-The security of **did:btc1** identifiers depends on the security of Schnorr
-signatures over the secp256k1 curve. It is this signature scheme that is used
-to secure both the Beacon Signals and DID Update Payloads. Should vulnerabilities
+The security of **did:btc1** identifiers depends on the security of ::Schnorr
+Signatures:: over the secp256k1 curve. It is this signature scheme that is used
+to secure both the ::Beacon Signals:: and ::DID Update Payloads::. Should vulnerabilities
 be discovered in this scheme or if advancements in quantum computing compromise
 its cryptographic foundations, the **did:btc1** method would become obsolete.
 
@@ -78,7 +78,7 @@ its cryptographic foundations, the **did:btc1** method would become obsolete.
 
 The security of **did:btc1** identifiers depends on the security of the Bitcoin
 blockchain. Should the Bitcoin blockchain become compromised such that its history
-could be rewritten, for example through a 51% attack, then Beacon Signals that
+could be rewritten, for example through a 51% attack, then ::Beacon Signals:: that
 were once part of the blockchain could be removed or replaced--although the longer
 these Signals have been included in the blockchain the more difficult this becomes.
 A 51% attack could prevent future Beacon Signals from being included within the

--- a/chapters/Terminology.md
+++ b/chapters/Terminology.md
@@ -3,131 +3,174 @@
 Beacon
 
 : A Beacon is the mechanism by which updates to DID documents are announced and
-discovered. Beacons are identified by a Bitcoin address which is included as a
-service endpoint in a DID document along with a specific Beacon Type. By spending
-from a Beacon address, DID controllers announce that an update to their DID has
-occurred (in the case of a SingletonBeacon) or may have occurred (in the case
-of a CIDAggregator or SMTAggregator Beacons).
+  discovered.
+
+  Beacons are identified by a Bitcoin address which is included as a
+  service endpoint in a DID document along with a specific ::Beacon Type::. By spending
+  from a Beacon address, DID controllers announce that an update to their DID has
+  occurred (in the case of a SingletonBeacon) or may have occurred (in the case
+  of a CIDAggregator or SMTAggregator Beacons).
 
 Singleton Beacon
 
 : A Singleton Beacon enables a single entity to independently post a DID Update
-Payload in a Beacon Signal.
+  Payload in a ::Beacon Signal::.
 
 Aggregate Beacon
 
 : An Aggregate Beacon enables multiple entities (possibly controlling multiple
-DIDs and possibly posting multiple updates) to collectively announce a set of
-DID Update Payloads in a Beacon Signal. There can only ever be one DID Update
-Payload per **did:btc1** in a Beacon Signal from an Aggregate Beacon.
+  DIDs and possibly posting multiple updates) to collectively announce a set of
+  ::DID Update Payloads:: in a ::Beacon Signal::.
+
+  There can only ever be one DID Update Payload per **did:btc1** in a Beacon
+  Signal from an Aggregate Beacon.
 
 Beacon Type
 
-: This document describes three specific Beacon Types: a SingletonBeacon, and two
-Aggregate Beacons, a CIDAggregateBeacon and a SMTAggregateBeacon.
+: One of SingletonBeacon, CIDAggregateBeacon, or SMTAggregateBeacon.
+
+Beacon Types
+
+: ::Beacon Type::
 
 Beacon Signal
 
 : Beacon Signals are Bitcoin transactions that spend from a Beacon address and
-include a transaction output of the format `[OP_RETURN, <32_bytes>]`. Beacon
-Signals announce one or more DID Update Payloads and provide a means for these
-payloads to be verified as part of the Beacon Signal. The type of the Beacon
-determines how these Beacon Signals SHOULD be constructed and processed to
-validate a set of DID Update Payloads against the 32 bytes contained within
-the Beacon Signal.
+  include a transaction output of the format `[OP_RETURN, <32_bytes>]`. Beacon
+  Signals announce one or more ::DID Update Payloads:: and provide a means for these
+  payloads to be verified as part of the Beacon Signal.
+
+  The type of the Beacon  determines how these Beacon Signals SHOULD be
+  constructed and processed to validate a set of DID Update Payloads against the
+  32 bytes contained within the Beacon Signal.
+
+Beacon Signals
+
+: ::Beacon Signal::
 
 Authorized Beacon Signal
 
-: An Authorized Beacon Signal is a Beacon Signal from a Beacon with a Beacon
-address in a then-current DID document.
+: An Authorized Beacon Signal is a ::Beacon Signal:: from a ::Beacon:: with a Beacon
+  address in a then-current DID document.
 
 DID Update Payload
 
-: A capability invocation secured using Data Integrity that invokes the root
-capability to update a specific **did:btc1**. The signed payload includes a
-JSON Patch object defining a set of mutations to the DID document being updated.
+: A capability invocation secured using Data Integrity that invokes the root 
+  capability to update a specific **did:btc1**. The signed payload includes a
+  JSON Patch object defining a set of mutations to the DID document being updated.
+
+DID Update Payloads
+
+: ::DID Update Payload::
 
 DID Update Bundle
 
-: A JSON object that maps **did:btc1** identifiers to Content Identifiers (CIDs)
-that identify DID Update Payloads for the identified DID. DID Update Bundles
-are announced by CIDAggregator Beacons.
+: A JSON object that maps **did:btc1** identifiers to ::Content Identifiers:: (CIDs)
+  that identify ::DID Update Payloads:: for the identified DID. DID Update Bundles
+  are announced by CIDAggregator Beacons.
 
 Merkle Tree
 
 : A tree data structure in which the leaves are a hash of a data block and every
-node that is not a leaf is a hash of its child node values. The root of a Merkle
-tree is a single hash that is produced by recursively hashing the child nodes
-down to the leaves of the tree. Given the root of a Merkle tree it is possible
-to provide a Merkle path that proves the inclusion of some data in the tree.
+  node that is not a leaf is a hash of its child node values.
 
-Sparse Merkle Tree (SMT)
+  The root of a Merkle tree is a single hash that is produced by recursively
+  hashing the child nodes down to the leaves of the tree. Given the root of a
+  Merkle tree it is possible to provide a Merkle path that proves the inclusion
+  of some data in the tree.
 
-: A Sparse Merkle Tree (SMT) is a Merkle tree where each data point included at
-the leaf of the tree is indexed. This data structure enables proofs of both
-inclusion and non-inclusion of data at a given index. The instantiation in this
-specification has 2^256 leaves that are indexed by the SHA256 hash of a **did:btc1**
-identifier. The data attested to at the leaves of the tree is the DID Update Payload
-for that **did:btc1** identifier that indexed to the leaf.
+Sparse Merkle Tree
+
+: A Sparse Merkle Tree (SMT) is a ::Merkle Tree:: where each data point included
+  at the leaf of the tree is indexed.
+
+  This data structure enables proofs of both inclusion and non-inclusion of data
+  at a given index. The instantiation in this specification has 2^256 leaves
+  that are indexed by the SHA256 hash of a **did:btc1** identifier. The data
+  attested to at the leaves of the tree is the ::DID Update Payload:: for that
+  **did:btc1** identifier that indexed to the leaf.
 
 Invocation
 
 : See https://w3c-ccg.github.io/zcap-spec/#terminology
 
-Schnorr Signatures
+Schnorr Signature
 
 : An alternative to ECDSA signatures with some major advantages, such as being able
-to combine digital signatures from multiple parties to form a single digital
-signature for the composite public key. Bitcoin Schnorr signatures are still
-over the secp256k1 curve, so the same keypairs can be used to produce both
-Schnorr signatures and ECDSA signatures.
+  to combine digital signatures from multiple parties to form a single digital
+  signature for the composite public key.
+
+  Bitcoin Schnorr signatures are still over the secp256k1 curve, so the same
+  keypairs can be used to produce both Schnorr signatures and ECDSA signatures.
+
+Schnorr Signatures
+
+: ::Schnorr Signature::
 
 Taproot
 
 : Taproot is an upgrade to the Bitcoin blockchain implemented in November 2021.
-This upgrade enabled Bitcoin transactions to be secured using Schnorr signatures
-through the introduction of a new address, a Taproot address.
+  This upgrade enabled Bitcoin transactions to be secured using Schnorr signatures
+  through the introduction of a new address, a Taproot address.
 
-Unspent Transaction Output (UTXO)
+Unspent Transaction Output
 
 : A Bitcoin transaction takes in transaction outputs as inputs and creates new
-transaction outputs potentially controlled by different addresses. An Unspent
-Transaction Output (UTXO) is a transaction output from a Bitcoin transaction
-that has not yet been included as an input, and hence spent, within another
-Bitcoin transaction.
+  transaction outputs potentially controlled by different addresses. An Unspent
+  Transaction Output (UTXO) is a transaction output from a Bitcoin transaction
+  that has not yet been included as an input, and hence spent, within another
+  Bitcoin transaction.
 
-Content Identifier (CID)
+UTXO
+
+: ::Unspent Transaction Output::
+
+Content Identifier
 
 : A Content Identifier (CID) is an identifier for some digital content (e.g., a
-file) generated from the content itself such that for any given content and CID
-generation algorithm there is a single, unique, collision-resistant identifier.
-This is typically done through some hashing function.
+  file) generated from the content itself such that for any given content and CID
+  generation algorithm there is a single, unique, collision-resistant identifier.
+  This is typically done through some hashing function.
 
-Content Addressable Storage (CAS)
+Content Identifiers
+
+: ::Content Identifier::
+
+CID
+
+: ::Content Identifier::
+
+Content Addressable Storage
 
 : Content Addressable Storage (CAS) is a data storage system where content is
-addressable using Content Identifiers (CIDs). The Interplanetary File System
-(IPFS) is an example of CAS.
+  addressable using Content Identifiers (CIDs). The Interplanetary File System
+  (IPFS) is an example of CAS.
+
+CAS
+
+: ::Content Addressable Storage::
 
 Non-Repudiation
 
 : Non-Repudiation is a feature of DID Methods that can clearly state that all data
-is available to present one canonical history for a DID. If some data is needed
-but not available, the DID Method MUST NOT allow DID resolution to complete.
-Any changes to the history, such as may occur if a website edits a file, MUST be
-detected and disallowed. The Late Publishing problem breaks Non-Repudiation.
+  is available to present one canonical history for a DID.
+
+  If some data is needed but not available, the DID Method MUST NOT allow DID
+  resolution to complete. Any changes to the history, such as may occur if a website
+  edits a file, MUST be detected and disallowed. The ::Late Publishing:: problem
+  breaks Non-Repudiation.
 
 Late Publishing
 
 : Late Publishing is the ability for DID updates to be revealed at a later point
-in time, which alters the history of a DID document such that a state, that
-appeared valid before the reveal, appears after Late Publishing to never have
-been valid. Late Publishing breaks Non-Repudiation.
+  in time, which alters the history of a DID document such that a state, that
+  appeared valid before the reveal, appears after Late Publishing to never have
+  been valid. Late Publishing breaks ::Non-Repudiation::.
 
 Offline Creation
 
 : Offline creation refers to when a **did:btc1** identifier and corresponding
-initial DID document are created without requiring network interactions.
+  initial DID document are created without requiring network interactions.
 
 **did:btc1** supports offline creation in two modes:
 * Key Pair Deterministic Creation; and
@@ -136,12 +179,12 @@ initial DID document are created without requiring network interactions.
 Sidecar
 
 : A mechanism by which data necessary for resolving a DID is provided alongside
-the **did:btc1** identifier being resolved, rather than being retrieved through
-open and standardized means (e.g., by retrieving from IPFS).
+  the **did:btc1** identifier being resolved, rather than being retrieved through
+  open and standardized means (e.g., by retrieving from IPFS).
 
 : To explain the metaphor, a sidecar on a motorcycle brings along a second passenger
-in a transformed vehicle, the same way the DID controller MUST bring along the
-DID Document history to transform the situation into one that is verifiable.
+  in a transformed vehicle, the same way the DID controller MUST bring along the
+  DID Document history to transform the situation into one that is verifiable.
 
 Sidecar Data
 
@@ -150,7 +193,7 @@ Sidecar Data
 Signal Blockheight
 
 : The blockheight of the Bitcoin block that included a specific Beacon Signal.
-Blockheight is used as the internal time of the resolution algorithm.
+  Blockheight is used as the internal time of the resolution algorithm.
 
 Resolution Time
 
@@ -159,11 +202,11 @@ Resolution Time
 Target Time
 
 : A UTC timestamp that specifies a target time provided by a client in a resolution
-request to the resolver. If none is provided the target time is set to the
-resolution time.
+  request to the resolver. If none is provided the target time is set to the
+  resolution time.
 
 Contemporary Blockheight
 
 : The blockheight of consideration when walking the provenance of a series of DID
-updates. A DID document's contemporary time is the Signal Time of the Beacon Signal
-that announced the last DID Update Payload applied to the DID document.
+  updates. A DID document's contemporary time is the Signal Time of the Beacon Signal
+  that announced the last ::DID Update Payload:: applied to the DID document.

--- a/chapters/Update-Beacons.md
+++ b/chapters/Update-Beacons.md
@@ -2,17 +2,17 @@
 
 Beacons are the mechanism by which a DID controller announces an update to their
 DID document by broadcasting an attestation to this update onto the public Bitcoin
-network. Beacons are identified by a Bitcoin address and emit Beacon Signals by
+network. Beacons are identified by a Bitcoin address and emit ::Beacon Signals:: by
 broadcasting a valid Bitcoin transaction that spends from this Beacon address.
 These transactions include attestations to a set of `didUpdatePayload`s, either
-in the form of Content Addressable Identifiers (CIDs) or Sparse Merkle Tree (SMT)
+in the form of Content Addressable Identifiers (CIDs) or ::Sparse Merkle Tree:: (SMT)
 roots. Beacons are included as a service in DID documents, with the Service Endpoint
 identifying a Bitcoin address to watch for Beacon Signals. All Beacon Signals
 broadcast from this Beacon MUST be processed as part of resolution
 (see [Read]). The type of the Beacon service in the DID document
 defines how Beacon Signals SHOULD be processed.
 
-**did:btc1** supports different Beacon Types, with each type defining a set of
+**did:btc1** supports different ::Beacon Types::, with each type defining a set of
 algorithms for:
 
 1. How a Beacon can be established and added as a service to a DID document.
@@ -40,7 +40,7 @@ this specification.
 #### Establish Beacon
 
 A Singleton Beacon is a Beacon that can be used to publish a single DID Update
-Payload targeting a single DID document. The serviceEndpoint for this Beacon Type
+Payload targeting a single DID document. The serviceEndpoint for this ::Beacon Type::
 is a Bitcoin address represented as a URI following the
 [BIP21 scheme](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki).
 It is RECOMMENDED that this Bitcoin address be under the sole control of the
@@ -70,8 +70,8 @@ The algorithm is as follows:
 #### Broadcast DID Update Attestation
 
 This algorithm is called from [Update], step 8, if the
-Beacon being used is of the type SingletonBeacon. A Content Identifier, `cid`,
-for the DID Update Payload the DID controller wishes to broadcast and a `beacon`
+Beacon being used is of the type SingletonBeacon. A ::Content Identifier::, `cid`,
+for the ::DID Update Payload:: the DID controller wishes to broadcast and a `beacon`
 object are passed into the algorithm. The Beacon constructs a Bitcoin transaction
 that spends from the Beacon address to a transaction output of the format
 `[OP_RETURN, OP_PUSH32, cid]` and broadcasts this to the Bitcoin network.
@@ -95,19 +95,19 @@ Updates) with `tx` passed in.
    then return. Bitcoin transaction is not a Beacon signal.
 1. Set `cid` to the 32 bytes in `txOut`.
 1. Set `didUpdatePayload` to the result of retrieving `cid` from Content Addressable
-   Storage (CAS) or Sidecar data. If not found MUST raise a `latePublishError`.
+   Storage (CAS) or ::Sidecar:: data. If not found MUST raise a `latePublishError`.
 1. Return `didUpdatePayload`.
 
 ### CIDAggregator Beacon
 
 A Beacon of the type CIDAggregatorBeacon is a Beacon that publishes Bitcoin
-transactions containing a Content Identifier (CID) announcing an Aggregated
+transactions containing a ::Content Identifier:: (CID) announcing an Aggregated
 DID Update Bundle. An Aggregated DID Update Bundle is a JSON object that maps
-**did:btc1** identifiers to CID values for the individual DID Update Payloads.
-The aggregated DID Update Bundle CID (bundleCID) SHOULD be resolvable against a
-Content Addressable Storage (CAS) system such as IPFS, while the CID for the DID
+**did:btc1** identifiers to CID values for the individual ::DID Update Payloads::.
+The Aggregated DID Update Bundle CID (bundleCID) SHOULD be resolvable against a
+::Content Addressable Storage:: (CAS) system such as IPFS, while the CID for the DID
 Update payload (payloadCID) MAY be resolvable against a CAS or provided through
-a Sidecar mechanism. It is RECOMMENDED that this type of Beacon is only included
+a ::Sidecar:: mechanism. It is RECOMMENDED that this type of Beacon is only included
 in a DID document if the DID controller is REQUIRED to participate in authorizing
 Bitcoin transactions from this Beacon. In other words, this Beacon SHOULD identify
 an n-of-n P2TR Bitcoin address where n is the number of unique DID controllers
@@ -142,7 +142,7 @@ proofs of control, and producing Beacon addresses.
 Any entity MAY act in the role of Beacon coordinator, creating a Beacon advertisement
 that they can broadcast across any medium. A Beacon advertisement specifies the
 properties of the Beacon that the coordinator intends to establish, including the
-Beacon Type, cohort size, update frequency, and response latency. Once the
+::Beacon Type::, cohort size, update frequency, and response latency. Once the
 advertisement has been created and broadcast, the coordinator waits for enough
 participants to opt in before establishing the Beacon.
 
@@ -181,9 +181,9 @@ BIP21:
 #### Broadcast DID Update Attestation
 
 This is an algorithm involving two roles: a set of cohort participants and a
-Beacon coordinator. The Beacon coordinator collects individual DID Update Payload
-Content Identifiers (CIDs) for specific **did:btc1**s and aggregates them into a
-DID Update Bundle, which is then published to a Content Addressable Storage (CAS).
+Beacon coordinator. The Beacon coordinator collects individual ::DID Update Payload::
+::Content Identifiers:: (CIDs) for specific **did:btc1**s and aggregates them into a
+::DID Update Bundle::, which is then published to a ::Content Addressable Storage:: (CAS).
 The CID for the DID Update Bundle is included in a Partially Signed Bitcoin
 Transaction (PSBT) transaction output spent from the Beacon's `n-of-n` address.
 Each of the `n` cohort participants in the Beacon MUST sign the transaction before
@@ -227,7 +227,7 @@ sequenceDiagram
 
 ##### Submit DID Update
 
-A cohort participant submits a CID for a DID Update Payload along with the DID
+A cohort participant submits a CID for a ::DID Update Payload:: along with the DID
 the update is for to the Beacon coordinator for a Beacon identified in their
 DID document.
 
@@ -240,27 +240,27 @@ Beacon cohort participants for authorization.
 
 ##### Authorize Beacon Signal
 
-On receiving an Authorize Beacon Signal request, DID controllers MUST verify
-that the DID Update Bundle either includes the CID for the DID Update Payload
+On receiving an ::Authorized Beacon Signal:: request, DID controllers MUST verify
+that the ::DID Update Bundle:: either includes the CID for the ::DID Update Payload::
 they submitted, or includes no entry for their DID. Once satisfied, the
 DID controller signs the PSBT following the MuSig2 protocol using the key they
 generated when establishing the Beacon.
 
 ##### Broadcast Beacon Signal
 
-Once all Beacon cohort participants have authorized the Beacon Signal by
+Once all Beacon cohort participants have authorized the ::Beacon Signal:: by
 signing the PSBT, a valid, spendable Bitcoin transaction can be created by
 aggregating the signatures following Schnorr. This Bitcoin transaction can then
 be broadcast to the network.
 
 #### Process Beacon Signal
 
-A Beacon Signal from a CIDAggregator Beacon is a Bitcoin transaction that contains
-a `bundleCID` referencing a DID Update Bundle in its first transaction output.
+A ::Beacon Signal:: from a CIDAggregator Beacon is a Bitcoin transaction that contains
+a `bundleCID` referencing a ::DID Update Bundle:: in its first transaction output.
 The bundle MUST be retrieved and then the relevant `payloadCID` for the DID Update
 payload of the specific DID being resolved MUST be identified and the content
 is retrieved. If the content identified by either CID cannot be retrieved, either
-from the CAS or through Sidecar at any point, a LatePublishing error MUST be
+from the CAS or through ::Sidecar:: at any point, a LatePublishing error MUST be
 raised. If the DID Update Bundle contains no CID for the relevant DID, then the
 Beacon Signal is ignored.
 
@@ -283,10 +283,10 @@ Beacon Signal is ignored.
 
 ### SMTAggregator Beacon
 
-A SMTAggregator Beacon is a Beacon whose Beacon Signals are Bitcoin transactions
-containing the root of a Sparse Merkle Tree (SMT). The SMT root attests to a
-set of DID Update Payloads, however, the updates themselves MUST be provided
-along with a proof of inclusion against the SMT root through a Sidecar mechanism
+A SMTAggregator Beacon is a Beacon whose ::Beacon Signals:: are Bitcoin transactions
+containing the root of a ::Sparse Merkle Tree:: (SMT). The SMT root attests to a
+set of ::DID Update Payloads::, however, the updates themselves MUST be provided
+along with a proof of inclusion against the SMT root through a ::Sidecar:: mechanism
 during resolution. Using the SMT root a resolver can then verify the inclusion
 proof for the given DID Update Payload. If a DID document includes a SMTAggregator
 Beacon in their set of Beacon services, then they MUST provide proofs for each
@@ -310,8 +310,8 @@ for each DID.
 
 #### Broadcast DID Update Attestation
 
-To publish a DID Update Payload, the DID controller MUST get a hash of the DID
-Update Payload included at the leaf of the Sparse Merkle Tree (SMT) identified by
+To publish a ::DID Update Payload::, the DID controller MUST get a hash of the DID
+Update Payload included at the leaf of the ::Sparse Merkle Tree:: (SMT) identified by
 their **did:btc1** identifier and receive an inclusion proof for this data. If
 a member of the Beacon cohort does not wish to announce an update in a Beacon
 Signal, they MUST receive and verify a proof of non-inclusion for their DID.
@@ -320,7 +320,7 @@ Beacon signal, they SHOULD accept and authorize the signal following the MuSig2
 protocol. Once all members of the cohort have authorized the signal, it can be
 broadcast as a transaction to the Bitcoin network. DID controllers are responsible
 for persisting their DID updates and proofs, these will need to be provided through
-a Sidecar mechanism during a resolution process.
+a ::Sidecar:: mechanism during a resolution process.
 
 ```mermaid
 sequenceDiagram
@@ -348,11 +348,11 @@ sequenceDiagram
 
 #### Process Beacon Signal
 
-Beacon Signals broadcast from SMTAggregator Beacons are expected to be a Bitcoin
+::Beacon Signals:: broadcast from SMTAggregator Beacons are expected to be a Bitcoin
 transaction with the first transaction output of the format
 `[OP_RETURN, OP_PUSH32, 32Bytes]`, where the 32 bytes are interpreted as a root
-to a Sparse Merkle Tree (SMT) that aggregates a set of hashes of DID Update
-Payloads. To retrieve and validate a DID Update Payload for a specific DID, the
+to a ::Sparse Merkle Tree:: (SMT) that aggregates a set of hashes of DID Update
+Payloads. To retrieve and validate a ::DID Update Payload:: for a specific DID, the
 resolver MUST receive (out of band) the SMT proof and DID Update Payload for a
 specific DID. This is typically provided by the DID controller. Using the SMT
 root from the Beacon Signal, the resolver can check the proof, gaining confidence

--- a/pandoc-spec.options.json
+++ b/pandoc-spec.options.json
@@ -4,7 +4,7 @@
   "autoDate": true,
   "inputDirectory": "chapters",
   "inputFile": [
-    "../README.md",
+    "Index.md",
     "Introduction-and-Motivation.md",
     "Terminology.md",
     "Syntax.md",


### PR DESCRIPTION
- Moved top content to chapters directory and simplified README.
- Put authors and contributors in table form.
- Applied pandoc-defref to terminology.