### PR TITLE
Rewrite update beacons

### DIFF
--- a/chapters/Appendix.md
+++ b/chapters/Appendix.md
@@ -63,3 +63,17 @@ The function returns the `canonicalizedBytes`.
 1. Set `hashBytes` to the result of applying the SHA256 cryptographic hashing
    algorithm to the `canonicalBytes`.
 1. Return `hashBytes`.
+
+### Fetch Content from Addressable Storage
+
+A macro function that takes in SHA256 hash of some content, `hashBytes`, converts these 
+bytes to a IPFS v1 ::Content Identifier:: and attempts to retrieve the identified content 
+from ::Content Addressable Storage:: (CAS). 
+
+The function returns the retrieved `content` or null.
+
+1. Set `cid` to the result of converting `hashBytes` to an IPFS v1 ::CID::.
+1. Set `content` to the result of fetching the `cid` from a ::CAS:: system. Which ::CAS:: systems 
+   checked is left to the implementation. TODO: Is this right? Are implementations just supposed to check all CAS they trust?
+1. If content for `cid` cannot be found, set `content` to null.
+1. Return `content`

--- a/chapters/CRUD-Operations.md
+++ b/chapters/CRUD-Operations.md
@@ -612,7 +612,7 @@ This algorithm takes in a `capabilityId` and returns a `rootCapability` object.
    1. `components[1] == zcap`.
    1. `components[2] == root`.
 1. Set `uriEncodedId` to `components[3]`.
-1. Set `bct1Identifier` the result of `decodeURIComponent(uriEncodedId)`.
+1. Set `btc1Identifier` the result of `decodeURIComponent(uriEncodedId)`.
 1. Set `rootCapability.id` to `capabilityId`.
 1. Set `rootCapability.controller` to `btc1Identifier`.
 1. Set `rootCapability.invocationTarget` to `btc1Identifier`.

--- a/chapters/CRUD-Operations.md
+++ b/chapters/CRUD-Operations.md
@@ -510,9 +510,8 @@ three ::Beacon Types::: `SingletonBeacon`, `CIDAggregateBeacon`, and
 1. Set `didUpdateInvocation` to the result of passing `btc1Identifier`,
    `unsignedUpdate` as `didUpdatePayload, `and `verificationMethod` to the
    [Invoke DID Update Payload] algorithm.
-1. Set `signalsMetadata` to the result of passing `sourceDocument`, `beaconIds` and
-   `didUpdateInvocation` to the
-   [Announce DID Update] algorithm.
+1. Set `signalsMetadata` to the result of passing `btc1Identifier`, `sourceDocument`, 
+   `beaconIds` and `didUpdateInvocation` to the [Announce DID Update] algorithm.
 1. Return `signalsMetadata`. It is up to implementations to ensure that the
    `signalsMetadata` is persisted.
 
@@ -623,10 +622,10 @@ This algorithm takes in a `capabilityId` and returns a `rootCapability` object.
 1. Set `rootCapability` to an empty object.
 1. Set `components` to the result of `capabilityId.split(":")`.
 1. Validate `components`:
-    1. Assert length of `components` is 4.
-    1. `components[0] == urn`.
-    1. `components[1] == zcap`.
-    1. `components[2] == root`.
+   1. Assert length of `components` is 4.
+   1. `components[0] == urn`.
+   1. `components[1] == zcap`.
+   1. `components[2] == root`.
 1. Set `uriEncodedId` to `components[3]`.
 1. Set `bct1Identifier` the result of `decodeURIComponent(uriEncodedId)`.
 1. Set `rootCapability.id` to `capabilityId`.
@@ -655,8 +654,8 @@ be mutated.
 
 #### Announce DID Update
 
-This algorithm takes in a `sourceDocument`, an array of `beaconIds`, and a
-`didUpdateInvocation`. It retrieves `beaconServices` from the `sourceDocument`
+This algorithm takes in a `btc1Identifier`, `sourceDocument`, an array of `beaconIds`, 
+and a `didUpdateInvocation`. It retrieves `beaconServices` from the `sourceDocument`
 and calls the Broadcast DID Update algorithm corresponding the type of
 the ::Beacon::. The algorithm returns an array of `signalsMetadata`, containing the
 necessary data to validate the ::Beacon Signal:: against the `didUpdateInvocation`.
@@ -664,28 +663,28 @@ necessary data to validate the ::Beacon Signal:: against the `didUpdateInvocatio
 1. Set `beaconServices` to an empty array.
 1. Set `signalMetadata` to an empty array.
 1. For `beaconId` in `beaconIds`:
-    1. Find `beaconService` in `sourceDocument.service` with an `id` property
-       equal to `beaconId`.
-    1. If no `beaconService` MUST throw `beaconNotFound` error.
-    1. Push `beaconService` to `beaconServices`.
+   1. Find `beaconService` in `sourceDocument.service` with an `id` property
+    equal to `beaconId`.
+   1. If no `beaconService` MUST throw `beaconNotFound` error.
+   1. Push `beaconService` to `beaconServices`.
 1. For `beaconService` in `beaconServices`:
-    1. If `beaconService.type` == `SingletonBeacon`:
-        1. Set `signalMetadata` to the result of
-           passing `beaconService` and `didUpdateInvocation` to the
-           [Broadcast Singleton Beacon Signal] algorithm.
-        1. Merge `signalMetadata` into `signalsMetadata`.
-    1. Else If `beaconService.type` == `CIDAggregateBeacon`:
-        1. Set `signalMetadata` to the result of
-           passing `beaconService` and `didUpdateInvocation` to the
-           [Broadcast CIDAggregate Beacon Signal] algorithm.
-        1. Push `signalMetadata` to `signalsMetadata`.
-    1. Else If `beaconService.type` == `SMTAggregateBeacon`:
-        1. Set `signalMetadata` to the result of
-           passing `beaconService` and `didUpdateInvocation` to the
-           [Broadcast SMTAggregate Beacon Signal] algorithm.
-        1. Merge `signalMetadata` to `signalsMetadata`.
-    1. Else:
-        1. MUST throw `invalidBeacon` error.
+   1. Set `signalMetadata` to null.
+   1. If `beaconService.type` == `SingletonBeacon`:
+      1. Set `signalMetadata` to the result of
+        passing `beaconService` and `didUpdateInvocation` to the
+        [Broadcast Singleton Beacon Signal] algorithm.
+   1. Else If `beaconService.type` == `CIDAggregateBeacon`:
+      1. Set `signalMetadata` to the result of
+        passing `btc1Identifier`, `beaconService` and `didUpdateInvocation` to the
+        [Broadcast CIDAggregate Beacon Signal] algorithm.
+   1. Else If `beaconService.type` == `SMTAggregateBeacon`:
+      1. Set `signalMetadata` to the result of
+        passing `btc1Identifier`, `beaconService` and `didUpdateInvocation` to the
+        [Broadcast SMTAggregate Beacon Signal] algorithm.
+   1. Else:
+      1. MUST throw `invalidBeacon` error.
+  1. Merge `signalMetadata` into `signalsMetadata`.
+
 1. Return `signalsMetadata`.
 
 ### Deactivate

--- a/chapters/CRUD-Operations.md
+++ b/chapters/CRUD-Operations.md
@@ -195,42 +195,25 @@ through signatures from the `keyBytes`'s associated private key.
 Each ::Beacon:: is of the type SingletonBeacon. The algorithm returns a `services` array.
 
 1. Initialize a `services` variable to an empty array.
-1. Set `beaconType` to `SingletonBeacon`.
 1. Set `serviceId` to `#initialP2PKH`.
 1. Set `beaconAddress` to the result of generating a Pay-to-Public-Key-Hash Bitcoin
    address from the `keyBytes` for the appropriate `network`.
-1. Set `p2pkhBeacon` to the result of passing `serviceId`, `beaconType`, and
-   `beaconAddress` to [Create Beacon Service].
+1. Set `p2pkhBeacon` to the result of passing `serviceId`, and
+   `beaconAddress` to [Establish Singleton Beacon].
 1. Push `p2pkhBeacon` to `services`.
 1. Set `serviceId` to `#initialP2WPKH`.
 1. Set `beaconAddress` to the result of generating a Pay-to-Witness-Public-Key-Hash
    Bitcoin address from the `keyBytes` for the appropriate `network`.
-1. Set `p2wpkhBeacon` to the result of passing `serviceId`, `beaconType`, and
-   `beaconAddress` to [Create Beacon Service].
+1. Set `p2wpkhBeacon` to the result of passing `serviceId`, and
+   `beaconAddress` to [Establish Singleton Beacon].
 1. Push `p2wpkhBeacon` to `services`.
 1. Set `serviceId` to `#initialP2TR`.
 1. Set `beaconAddress` to the result of generating a Pay-to-Taproot Bitcoin address
    from the `keyBytes` for the appropriate `network`.
-1. Set `p2trBeacon` to the result of passing `serviceId`, `beaconType`, and
-   `beaconAddress` to [Create Beacon Service].
+1. Set `p2trBeacon` to the result of passing `serviceId`, and
+   `beaconAddress` to [Establish Singleton Beacon].
 1. Push `p2trBeacon` to `services`.
 1. Return the `services` array.
-
-###### Create Beacon Service
-
-// TODO: This is a generic algorithm. Perhaps move to appendix.
-
-This algorithm creates a ::Beacon:: service that can be included into the services
-array of a DID document.
-The algorithm takes in a `serviceId`, a ::Beacon Type:: `beaconType`, and a
-`bitcoinAddress`. It returns a `service` object.
-
-1. Initialize a `beacon` variable to an empty object.
-1. Set `beacon.id` to `serviceId`.
-1. Set `beacon.type` to `beaconType`.
-1. Set `beacon.serviceEndpoint` to the result of converting `bitcoinAddress` to
-   a URI as per **[BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)**
-1. Return `beacon`.
 
 ##### External Resolution
 
@@ -521,7 +504,7 @@ three ::Beacon Types::: `SingletonBeacon`, `CIDAggregateBeacon`, and
    [Invoke DID Update Payload] algorithm.
 1. Set `signalsMetadata` to the result of passing `sourceDocument`, `beaconIds` and
    `didUpdateInvocation` to the
-   [Announce DID Update Payload] algorithm.
+   [Announce DID Update] algorithm.
 1. Return `signalsMetadata`. It is up to implementations to ensure that the
    `signalsMetadata` is persisted.
 
@@ -679,11 +662,11 @@ be mutated.
 }
 ```
 
-#### Announce DID Update Payload
+#### Announce DID Update
 
 This algorithm takes in a `sourceDocument`, an array of `beaconIds`, and a
 `didUpdateInvocation`. It retrieves `beaconServices` from the `sourceDocument`
-and calls the [Broadcast DID Update Attestation] algorithm corresponding the type of
+and calls the Broadcast DID Update algorithm corresponding the type of
 the ::Beacon::. The algorithm returns an array of `signalsMetadata`, containing the
 necessary data to validate the ::Beacon Signal:: against the `didUpdateInvocation`.
 
@@ -698,17 +681,17 @@ necessary data to validate the ::Beacon Signal:: against the `didUpdateInvocatio
     1. If `beaconService.type` == `SingletonBeacon`:
         1. Set `signalMetadata` to the result of
            passing `beaconService` and `didUpdateInvocation` to the
-           [Broadcast DID Update Attestation] algorithm.
+           [Broadcast DID Update] algorithm.
         1. Push `signalMetadata` to `signalsMetadata`.
     1. Else If `beaconService.type` == `CIDAggregateBeacon`:
-        1. Set `signalId` to the result of
+        1. Set `signalMetadata` to the result of
            passing `beaconService` and `didUpdateInvocation` to the
-           [Broadcast DID Update Attestation] algorithm.
+           [Broadcast DID Update] algorithm.
         1. Push `signalMetadata` to `signalsMetadata`.
     1. Else If `beaconService.type` == `SMTAggregateBeacon`:
         1. Push `signalMetadata` to `signalsMetadata`
            passing `beaconService` and `didUpdateInvocation` to the
-           [Broadcast DID Update Attestation] algorithm.
+           [Broadcast DID Update] algorithm.
         1. Push `signalMetadata` to `signalsMetadata`.
     1. Else:
         1. MUST throw `invalidBeacon` error.

--- a/chapters/Terminology.md
+++ b/chapters/Terminology.md
@@ -9,7 +9,7 @@ Beacon
   service endpoint in a DID document along with a specific ::Beacon Type::. By spending
   from a Beacon address, DID controllers announce that an update to their DID has
   occurred (in the case of a SingletonBeacon) or may have occurred (in the case
-  of a CIDAggregator or SMTAggregator Beacons).
+  of a CIDAggregate or SMTAggregate Beacons).
 
 Beacons
 

--- a/chapters/Update-Beacons.md
+++ b/chapters/Update-Beacons.md
@@ -50,28 +50,12 @@ the implementation.
 
 This algorithm takes in a Bitcoin `address` and a `serviceId` and returns a ::Singleton Beacon:: `service`.
 
-<<<<<<< HEAD
 1. Initialize a `service` variable to an empty object.
 1. Set `service.id` to `serviceId`.
 1. Set `service.type` to "SingletonBeacon".
 1. Set `service.serviceEndpoint` to the result of converting `address` to
    a URI as per **[BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)**
 1. Return `service`.
-=======
-1. Generate a secp256k1 keypair.
-1. Use the public key to generate a Bitcoin address. It is RECOMMENDED to use
-   either P2PKH, P2WPKH, P2TR. However, other custom Bitcoin addresses are still
-   valid. It is up to the DID controller to ensure the address is spendable by them alone.
-    1. It is possible to use an existing Bitcoin address.
-    1. Before the ::Beacon:: can be used to publish an update it MUST be funded.
-1. Set `beaconUri` to the URI for the address following BIP21.
-1. Initialize `beaconService` to the JSON string (interpolating values as needed):
-   ```{.json include="json/Update-Beacons/Singleton-initialize-beacon-service.json"}
-   ```
-   Note that the `casType` is optional and provides a hint at the CAS storage being used.
-1. Add `beaconService` to the DID document through an update following the algorithm
-   defined in [Update].
->>>>>>> main
 
 
 // TODO: Style and link to examples.

--- a/chapters/Update-Beacons.md
+++ b/chapters/Update-Beacons.md
@@ -126,7 +126,7 @@ an error.
 1. Else:
    1. Set `didUpdatePayload` to the result of passing `hashBytes` into the 
       [Fetch Content from Addressable Storage] algorithm.
-   1. If `didUpdatePayload` is null, MUST raise a `latePublishingError`. May identify Beacon Signal
+   1. If `didUpdatePayload` is null, MUST raise a `latePublishingError`. MAY identify Beacon Signal
       to resolver and request additional ::Sidecar data:: be provided.
 1. Return `didUpdatePayload`.
 
@@ -311,25 +311,25 @@ for the ::did:btc1:: identifier being resolved or throws an error.
    1. Set `bundleHashBytes` to the result of passing `didUpdateBundle` to the 
       [JSON Canonicalization and Hash] algorithm.
    1. If `bundleHashBytes` does not equal `hashBytes`, MUST raise an `invalidSidecarData` error. 
-      May identify Beacon Signal to resolver and request additional ::Sidecar data:: be provided.
+      MAY identify Beacon Signal to resolver and request additional ::Sidecar data:: be provided.
    1. Set `signalUpdateHashBytes` to `didUpdateBundle.get(btc1Identifier)`
-   1. If `signalUpdateHashBytes` is null, MUST raise an `incompleteSidecarData` error. May identify Beacon Signal
+   1. If `signalUpdateHashBytes` is null, MUST raise an `incompleteSidecarData` error. MAY identify Beacon Signal
       to resolver and request additional ::Sidecar data:: be provided.
    1. Set `didUpdatePayload` to `signalSidecarData.updatePayload`.
    1. Set `updateHashBytes` to the result of passing `didUpdatePayload` to the 
       [JSON Canonicalization and Hash] algorithm.
    1. If `signalUpdateHashBytes` does not equal `updateHashBytes`,  MUST raise an `invalidSidecarData` error. 
-      May identify Beacon Signal to resolver and request additional ::Sidecar data:: be provided.
+      MAY identify Beacon Signal to resolver and request additional ::Sidecar data:: be provided.
 1. Else:
    1. Set `didUpdateBundle` to the result of calling the [Fetch From Content Addressable Storage] algorithm passing 
       in `hashBytes`.
-   1. If `didUpdateBundle` is null, MUST raise a `latePublishingError`. May identify Beacon Signal
+   1. If `didUpdateBundle` is null, MUST raise a `latePublishingError`. MAY identify Beacon Signal
       to resolver and request additional ::Sidecar data:: be provided.
    1. Set `signalUpdateHashBytes` to the `didUpdateBundle.get(btc1Identifier)` 
    // TODO: Will need to decode this. Bundle is not going to store raw bytes
    1. Set `didUpdatePayload` to the result of calling the [Fetch From Content Addressable Storage] algorithm 
       passing in `signalUpdateHashBytes`.
-   1. If `didUpdatePayload` is null, MUST raise a `latePublishingError`. May identify Beacon Signal
+   1. If `didUpdatePayload` is null, MUST raise a `latePublishingError`. MAY identify Beacon Signal
       to resolver and request additional ::Sidecar data:: be provided.
 1. Return `didUpdatePayload` 
 
@@ -424,7 +424,7 @@ for the ::did:btc1:: identifier being resolved or throws an error.
 1. Initialize a `txOut` variable to the 0th transaction output of the `tx`.
 1. Check `txOut` is of the format `[OP_RETURN, OP_PUSH32, <32byte>]`, if not,
    then return null. The Bitcoin transaction is not a ::Beacon Signal::.
-1. If no `signalSidecarData`, MUST raise an `incompleteSidecarData` error. May identify the Beacon Signal
+1. If no `signalSidecarData`, MUST raise an `incompleteSidecarData` error. MAY identify the Beacon Signal
    to resolver and request additional ::Sidecar data:: be provided. 
 1. Set `smtProof` to `signalSidecarData.smtProof`.
 1. If no `smtProof`, MUST raise a `latePublishing` error.

--- a/chapters/Update-Beacons.md
+++ b/chapters/Update-Beacons.md
@@ -37,37 +37,36 @@ this specification.
 
 ### Singleton Beacon
 
-#### Establish Beacon
+#### Establish Singleton Beacon
 
 A ::Singleton Beacon:: is a ::Beacon:: that can be used to publish a single ::DID Update
 Payload:: targeting a single DID document. The serviceEndpoint for this ::Beacon Type::
 is a Bitcoin address represented as a URI following the
 [BIP21 scheme](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki).
 It is RECOMMENDED that this Bitcoin address be under the sole control of the
-DID controller.
+DID controller. How the Bitcoin address and the cryptographic material that controls it are generated is left to implementation.
 
-The algorithm is as follows:
+This algorithm takes in a Bitcoin `address` and a `serviceId` and returns a ::Singleton Beacon:: `service`.
 
-1. Generate a secp256k1 keypair.
-1. Use the public key to generate a Bitcoin address. It is RECOMMENDED to use
-   either P2PKH, P2WPKH, P2TR. However, other custom Bitcoin addresses are still
-   valid. It is up to the DID controller to ensure the address is spendable by them alone.
-    1. It is possible to use an existing Bitcoin address.
-    1. Before the ::Beacon:: can be used to publish an update it MUST be funded.
-1. Set `beaconUri` to the URI for the address following BIP21.
-1. Initialize `beaconService` to the JSON string (interpolating values as needed):
-   ```json
-   {
-       "id": "#singletonBeacon", 
-       "type": "SingletonBeacon", 
-       "serviceEndpoint": "${beaconUri}",
-       "casType": "IPFS" // Optional hint at the CAS storage used 
-   }
-   ```
-1. Add `beaconService` to the DID document through an update following the algorithm
-   defined in [Update].
+1. Initialize a `service` variable to an empty object.
+1. Set `service.id` to `serviceId`.
+1. Set `service.type` to "SingletonBeacon".
+1. Set `service.serviceEndpoint` to the result of converting `address` to
+   a URI as per **[BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)**
+1. Return `service`.
 
-#### Broadcast DID Update Attestation
+
+// TODO: Style and link to examples.
+```json
+{
+   "id": "#singletonBeacon", 
+   "type": "SingletonBeacon", 
+   "serviceEndpoint": "${beaconUri}",
+}
+```
+
+
+#### Broadcast DID Update
 
 This algorithm is called from [Update], step 8, if the
 ::Beacon:: being used is of the type SingletonBeacon. A ::Content Identifier::, `cid`,
@@ -178,7 +177,7 @@ BIP21:
 }
 ```
 
-#### Broadcast DID Update Attestation
+#### Broadcast DID Update
 
 This is an algorithm involving two roles: a set of cohort participants and a
 ::Beacon:: coordinator. The ::Beacon:: coordinator collects individual ::DID Update Payload::
@@ -308,7 +307,7 @@ Additionally, the SMTAggregator ::Beacon:: cohort participants MUST register the
 coordinator can generate the necessary proofs of both inclusion and non-inclusion
 for each DID.
 
-#### Broadcast DID Update Attestation
+#### Broadcast DID Update
 
 To publish a ::DID Update Payload::, the DID controller MUST get a hash of the ::DID
 Update Payload:: included at the leaf of the ::Sparse Merkle Tree:: (SMT) identified by

--- a/notebooks/Aggregation/Resolver.ipynb
+++ b/notebooks/Aggregation/Resolver.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "f3cfc50a-4231-40a8-8ea9-fe8d509ecf19",
    "metadata": {},
    "outputs": [],
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "345a339d-db40-4896-8b62-6ddb7da0a9e4",
    "metadata": {},
    "outputs": [
@@ -125,7 +125,7 @@
        "   'proof': '8004953e000000000000007d94288c09736964656e6f646573945d948c176e6f6e5f6d656d626572736869705f6c65616664617461944e8c0c7369626c696e675f64617461944e752e'}}}"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "2f9665f4-3a71-41fa-a9c7-deeb8c14e077",
    "metadata": {},
    "outputs": [],
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "4eac5886-be37-41db-90c6-cf2f0aa4a12f",
    "metadata": {},
    "outputs": [],
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "id": "67b86290-ff98-4795-b669-efa987d94c6b",
    "metadata": {},
    "outputs": [
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "id": "8d0fea82-db25-458b-baba-7e8690a556e1",
    "metadata": {},
    "outputs": [],
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 8,
    "id": "0b7bc29e-4690-4f27-a433-da5fea43454e",
    "metadata": {},
    "outputs": [
@@ -297,7 +297,7 @@
        "   'serviceEndpoint': 'bitcoin:tb1pfdnyc8vxeca2zpsg365sn308dmrpka4e0n9c5axmp2nptdf7j6ts7eqhr8'}]}"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 9,
    "id": "b7afdf62-d1be-44c8-a88c-e32f87911f46",
    "metadata": {},
    "outputs": [],
@@ -356,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 10,
    "id": "108d8b3b-541c-452e-a648-38cbf3362d73",
    "metadata": {},
    "outputs": [],
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 11,
    "id": "747a6cec-339f-470a-87ca-0f5e64372343",
    "metadata": {},
    "outputs": [],
@@ -396,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 12,
    "id": "1ac730e1-9d90-4049-8c73-7ba8ec7e29b9",
    "metadata": {},
    "outputs": [],
@@ -416,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 13,
    "id": "663bc18a-eb7c-4a15-b48a-4448d777d7a4",
    "metadata": {},
    "outputs": [],
@@ -437,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 14,
    "id": "329c3b53-b349-4ea2-b398-0bffffdffbfe",
    "metadata": {},
    "outputs": [],
@@ -716,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 15,
    "id": "503fb6eb-3d17-4f37-a2f7-d8dd1735f336",
    "metadata": {},
    "outputs": [],
@@ -780,6 +780,27 @@
     "        print(f\"\\nverified update for {did_to_resolve}:\\n{did_update_invocation}\\n\")\n",
     "        if did_update_invocation:\n",
     "            pending_updates.append(did_update_invocation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "8abab038-a707-4f99-bd9e-81c9557baaf5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on function verify_proof in module smt.proof:\n",
+      "\n",
+      "verify_proof(proof, root, key, value)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(verify_proof)"
    ]
   },
   {


### PR DESCRIPTION
This PR rewrites the Update Beacons section to following a similar algorithm style used in the CRUD operations.

Specifically it:

1. Rewrites all SingletonBeacon algorithms
2. Rewrites the Process Beacon Signal algorithm for CIDAggregate Beacons
3. Rewrites the Process Beacon Signal algorithm for SMTAggregate Beacons

The algorithms now align with the calls and expected inputs and outputs made from the CRUD section.