### PR TITLE
Change "genesisDocument" -> "initialDocument"

### DIFF
--- a/chapters/CRUD-Operations.md
+++ b/chapters/CRUD-Operations.md
@@ -225,7 +225,7 @@ takes in a **did:btc1** `identifier`, a `identifierComponents` object and a
 It returns an `initialDocument`, which is a conformant DID document validated
 against the `identifier`.
 
-1. If `resolutionOptions.sidecarData.genesisDocument` is not null, set
+1. If `resolutionOptions.sidecarData.initialDocument` is not null, set
    `initialDocument` to the result of passing `identifier`, `identifierComponents`
    and `resolutionOptions.sidecarData.initialDocument` into algorithm
    [Sidecar Initial Document Validation].


### PR DESCRIPTION
This part of the algorithm first mentions `resolutionOptions.sidecarData.genesisDocument`, but then `resolutionOptions.sidecarData.initialDocument`, but I think both should be the same, so either "genesisDocument" should be used in both places, or "initialDocument" in both places.