### PR TITLE
WIP: improve styling for table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The full specification may be viewed at http://dcdpr.github.io/did-btc1/.
 First, make sure you have 'pandoc' installed on your machine - https://pandoc.org/getting-started.html. Then you also need 'npm', a package manager for the JavaScript programming. Mac users can get both with homebrew: ```brew install npm pandoc``` 
 
 Then run:
+
 * ```cd did-btc1```
 * ```npm install```
 * ```npm run pandoc-spec-local```

--- a/chapters/Index.md
+++ b/chapters/Index.md
@@ -8,25 +8,24 @@ lang: en
 
 ### Authors: {.unnumbered .unlisted}
 
-+---------------+--------------------------+-----------------------------------------------------+
-| Ryan Grant    | <rgrant@contract.design> | [Digital Contract Design](https://contract.design/) |
-+---------------+--------------------------+-----------------------------------------------------+
-| Will Abramson | <will@legreq.com>        | [Legendary Requirements](https://legreq.com/)       |
-+---------------+--------------------------+-----------------------------------------------------+
-| Joe Andrieu   | <joe@legreq.com>         | [Legendary Requirements](https://legreq.com/)       |
-+---------------+--------------------------+-----------------------------------------------------+
-| Kevin Dean    | <kevin@legreq.com>       | [Legendary Requirements](https://legreq.com/)       |
-+---------------+--------------------------+-----------------------------------------------------+
-| Dan Pape      | <dpape@contract.design>  | [Digital Contract Design](https://contract.design/) |
-+---------------+--------------------------+-----------------------------------------------------+
-| Jennie Meier  | <jennie@contract.design> | [Digital Contract Design](https://contract.design/) |
-+---------------+--------------------------+-----------------------------------------------------+
+::: {.unformattedTable}
+------------- ------------------------ ---------------------------------------------------
+Ryan Grant    <rgrant@contract.design> [Digital Contract Design](https://contract.design/)
+Will Abramson <will@legreq.com>        [Legendary Requirements](https://legreq.com/) 
+Joe Andrieu   <joe@legreq.com>         [Legendary Requirements](https://legreq.com/)       
+Kevin Dean    <kevin@legreq.com>       [Legendary Requirements](https://legreq.com/)       
+Dan Pape      <dpape@contract.design>  [Digital Contract Design](https://contract.design/) 
+Jennie Meier  <jennie@contract.design> [Digital Contract Design](https://contract.design/) 
+------------- ------------------------ ---------------------------------------------------
+:::
 
 ### Contributors: {.unnumbered .unlisted}
 
-+---------------+--------------------------+
-| Kate Sills    | <katelynsills@gmail.com> |
-+---------------+--------------------------+
+::: {.unformattedTable}
+------------- ------------------------ ---------------------------------------------------
+Kate Sills    <katelynsills@gmail.com> 
+------------- ------------------------ ---------------------------------------------------
+:::
 
 ### Publication Date: 20th September 2024 {.unnumbered .unlisted}
 

--- a/chapters/Introduction-and-Motivation.md
+++ b/chapters/Introduction-and-Motivation.md
@@ -53,6 +53,7 @@ affects some other DID Methods.
 
 BTCR is the original Bitcoin DID Method.  It kept its focus on censorship
 resistance. It has the following limitations:
+
 * It is prohibitively expensive to maintain many DIDs, because both creation and
   every update require a separate on-chain transaction.
 * It requires storing the data for the DID document somewhere public and exposed
@@ -71,6 +72,7 @@ resistance. It has the following limitations:
 
 ION anchors on the Bitcoin blockchain following a Sidetree approach. It has the
 following limitations:
+
 * Although in the normal case where data is available this DID Method performs
   fine, it does not fully address the ::Late Publishing:: problem, and thus attackers
   may manipulate edge cases to create doubt about signatures used for attestation.
@@ -83,6 +85,7 @@ following limitations:
 This DID Method stores the entire DID document on-chain in transactions using
 "inscriptions".  Because of this, its main feature of totally on-chain data is
 also its main structural limitation:
+
 * Those transactions are very expensive.
 * They cannot be kept private.
 
@@ -93,6 +96,7 @@ batching mechanism that reduces overhead but still stores all data on-chain.
 Its documentation lists "subject keys" as a feature, but they are just talking
 about defining additional keys in a DID document, which all of these DID Methods
 provide. In summary its main limitations are:
+
 * Creation and update require expensive transactions.
 * did:btc does not contemplate a way to keep DID documents private.
 
@@ -116,6 +120,7 @@ provide. In summary its main limitations are:
 * Simple deterministic DIDs can be recovered from typical Bitcoin seed words.
 
 ### Limitations
+
 * Resolvers require read-only view of all blocks arriving at the Bitcoin blockchain.
 * DID controllers are responsible for providing the data referenced in their
   ::Beacons::' updates (although many ::Beacons:: are expected to provide an archival

--- a/chapters/index.css
+++ b/chapters/index.css
@@ -1,0 +1,55 @@
+html {
+    overflow: hidden;
+}
+
+.overflow-auto {
+    overflow-y: auto !important;
+    overflow-x: hidden;
+}
+
+
+#toc {
+    background-color: #eceff1;
+    padding: 1em 0.8em;
+    font-size: .85em;
+}
+
+#left-margin, #right-margin {
+    display: none;
+}
+
+#toc ul, #toc ul ul, #toc ul ul ul {
+    list-style: none;
+}
+
+.toc-section-number {
+    font-weight: 700;
+    color: #000;
+    padding: 0 .2em;
+}
+
+#toc ul li a {
+    display: block;
+    padding: .4em .3em .225em;
+    text-decoration: none;
+    border-radius: 3px;
+    color: #333;
+}
+
+#toc ul {
+    padding: 0 0 0 1em;;
+}
+
+#toc a:hover {
+    text-shadow: 0 1px 1px #fff;
+    background: rgba(0, 0, 0, .1);
+}
+
+#content {
+    box-sizing: border-box;
+    padding: .5em 2em 1.5em 2em;
+}
+
+#content h1:first-of-type {
+    margin: 1em 0 .5em;
+}

--- a/chapters/index.css
+++ b/chapters/index.css
@@ -2,12 +2,6 @@ html {
     overflow: hidden;
 }
 
-.overflow-auto {
-    overflow-y: auto !important;
-    overflow-x: hidden;
-}
-
-
 #toc {
     background-color: #eceff1;
     padding: 1em 0.8em;

--- a/chapters/index.css
+++ b/chapters/index.css
@@ -47,3 +47,29 @@ html {
 #content h1:first-of-type {
     margin: 1em 0 .5em;
 }
+
+table {
+    margin: .5em auto;
+}
+
+thead, tbody {
+    border: 2px solid #ddd;
+}
+
+th, td {
+    border: 1px solid #ddd;
+    padding: .25em .5em;
+}
+
+.unformattedTable table {
+    margin: .5em 0;
+}
+
+.unformattedTable :is(thead, tbody) {
+    border: 0;
+}
+
+.unformattedTable :is(th, td) {
+    border: 0;
+    padding: 0 .5em 0 0;
+}

--- a/pandoc-spec.options.json
+++ b/pandoc-spec.options.json
@@ -17,5 +17,6 @@
   ],
   "outputDirectory": "_site",
   "cleanOutput": true,
-  "outputFile": "index.html"
+  "outputFile": "index.html",
+  "cssFile": "index.css"
 }


### PR DESCRIPTION
This fixes some things that have been bugging me every time I look at the spec.

I would like to make some more changes. Just not sure if they should be done here or in the base pandoc spec repo - https://github.com/LegReq/pandoc-spec

Styling follows the styling used by DIF, e,g, https://identity.foundation/sidetree/spec