### PR TITLE
CRUD Update Section Edits

### DIFF
--- a/chapters/CRUD-Operations.md
+++ b/chapters/CRUD-Operations.md
@@ -573,7 +573,7 @@ it constructs and returns an unsigned ::DID Update Payload::.
 This algorithm takes in a `btc1Identifier`, an unsigned `didUpdatePayload`, and a
 `verificationMethod`. The algorithm retrieves the `privateKeyBytes` for the
 `verificationMethod` and adds a capability invocation in the form of a Data
-Integrity proof following the Authorization Capabilities for Linked Data (ZCAP-LD) and
+Integrity proof following the ZCAP-LD and
 Verifiable Credentials (VC) Data Integrity specifications.
 
 The algorithm returns the invoked ::DID Update Payload::.


### PR DESCRIPTION
Acronyms, caps, and links for the CRUD Update section.

@wip-abramson in 4.3.3 Announce DID Update the second sentence states "calls the Broadcast DID Update algorithm" but it doesn't link to anything. Does this need a link added, and if not, does it need to be capitalized? 