### PR TITLE
Security Considerations Section Edits

### DIFF
--- a/chapters/Security-Considerations.md
+++ b/chapters/Security-Considerations.md
@@ -5,15 +5,15 @@
 #### Late Publishing
 
 **did:btc1** was designed to avoid ::Late Publishing:: such that, independent of when
-a resolution occurs, the DID document history and provenance are guaranteed to
-be invariant. This is achieved through requiring strict ordering of DID updates
-and complete coverage of all relevant ::Beacon Signals::. Resolvers MUST process all
-relevant ::Beacon Signals:: and enforce strict ordering.
+a resolution occurs, the Decentralized Identifier (DID) document history and provenance are 
+guaranteed to be invariant. This is achieved through requiring strict ordering of 
+DID updates and complete coverage of all relevant ::Beacon Signals::. Resolvers MUST 
+process all relevant ::Beacon Signals:: and enforce strict ordering.
 
 Additionally, when resolvers are passed resolution options specifying a versionId 
 they MUST process the full history of the signals up to the current time in order 
 to check for late publishing. Any update that specifies the same versionId but 
-contains different update operations MUST trigger a late publishing error. This 
+contains different update operations MUST trigger a ::Late Publishing:: error. This 
 is not the case for versionTime. When a resolver is passed a versionTime option
 then the state of the DID document can be returned once the all the signals in 
 the blocks before this timestamp have been processed. 
@@ -45,7 +45,7 @@ a key.
 
 #### Aggregate Beacon Address Verification
 
-An Aggregate ::Beacon:: Address SHOULD be an n-of-n Pay-to-Taproot (P2TR) address,
+An ::Aggregate Beacon:: Address SHOULD be an n-of-n Pay-to-Taproot (P2TR) address,
 with a cohort key contributed to the n by each of the cohort participants. DID
 controllers participating in aggregation cohorts SHOULD verify the ::Beacon:: address
 is an n-of-n and that one of the n keys is the cohort key provided to the ::Beacon::
@@ -70,7 +70,7 @@ would be possible for an adversary to take control of a DID by submitting a ::DI
 Update Payload:: to a ::Beacon:: that replaces key material and ::Beacons:: in the DID
 document for ones under the adversary's control. Such an attack would be detectable
 by the DID controller, as they would see a valid spend from a ::Beacon:: that they
-did not authorize. Additionally, if the DID relied on ::Sidecar data::, without access
+did not authorize. Additionally, if the DID relied on ::Sidecar Data::, without access
 to this data the DID would be useless to the adversary as they would be unable
 to demonstrate a valid complete history of the DID during resolution.
 


### PR DESCRIPTION
Acronyms, caps, and links for the Security Considerations section.

@wip-abramson we capitalize the terms "Aggregators" and "Signals" in this section - should these remain capitalized or shift to lower-case?  