### PR TITLE
Fix formatting in Apply DID Update

### DIFF
--- a/chapters/CRUD-Operations.md
+++ b/chapters/CRUD-Operations.md
@@ -670,8 +670,8 @@ The steps are as follows:
    instance using the key referenced by the `verificationMethod` field in the update.
    ```{.json include="json/CRUD-Operations/Update-apply-did-update.json"}
    ```
-1. Set `expectedProofPurpose` to `capabilityInvocation`.
-1. Set `mediaType` to `application/ld+json`
+1. Set `expectedProofPurpose` to "capabilityInvocation".
+1. Set `mediaType` to "application/ld+json".
 1. Set `documentBytes` to the bytes representation of `update`.
 1. Set `verificationResult` to the result of passing `mediaType`, `documentBytes`,
    `cryptosuite`, and `expectedProofPurpose` into the


### PR DESCRIPTION
- These two variables are strings.
- Use the same formatting as other sections where strings are used.

E.g.:

1. Set `idType` to "key".
1. Set `idType` to "external".