### PR TITLE
Terminology did:btcr2 Updates

### DIFF
--- a/chapters/Terminology.md
+++ b/chapters/Terminology.md
@@ -1,14 +1,22 @@
 ## Terminology
 
+BTCR2 Beacon
+
+: A abstract mechanism, identified by a ::Beacon Address::, that is included as a service in a DID document to indicate to resolvers that spends from this address, called ::Beacon Signals::, should be discovered and checked for ::BTCR2 Update Announcements::. 
+
+BTCR2 Beacons
+
+: ::BTCR2 Beacon::
+
+: ::BTCR2 Beacon::
+
 BTC1 Beacon
 
-: A abstract mechanism, identified by a ::Beacon Address::, that is included as a service in a DID document to indicate to resolvers that spends from this address, called ::Beacon Signals::, should be discovered and checked for ::BTC1 Update Announcements::. 
+: ::BTCR2 Beacon::
 
 BTC1 Beacons
 
-: ::BTC1 Beacon::
-
-: ::BTC1 Beacon::
+: ::BTCR2 Beacon::
 
 Singleton Beacon
 
@@ -23,9 +31,9 @@ Aggregate Beacon
 
 : An Aggregate Beacon enables multiple entities (possibly controlling multiple
   DIDs and possibly posting multiple updates) to collectively announce a set of
-  ::BTC1 Updates:: in a ::Beacon Signal::.
+  ::BTCR2 Updates:: in a ::Beacon Signal::.
 
-  There can only ever be one ::BTC1 Update:: per **did:btc1** in a ::Beacon
+  There can only ever be one ::BTCR2 Update:: per **did:btcr2** in a ::Beacon
   Signal:: from an Aggregate Beacon.
 
 Aggregate Beacons
@@ -42,13 +50,13 @@ Beacon Types
 
 Beacon Signal
 
-: Beacon Signals are Bitcoin transactions that spend from a ::BTC1 Beacon:: address and
+: Beacon Signals are Bitcoin transactions that spend from a ::BTCR2 Beacon:: address and
   include a transaction output of the format `[OP_RETURN, <32_bytes>]`. Beacon
-  Signals announce one or more ::BTC1 Updates:: and provide a means for these
+  Signals announce one or more ::BTCR2 Updates:: and provide a means for these
   payloads to be verified as part of the Beacon Signal.
 
-  The type of the ::BTC1 Beacon::  determines how these Beacon Signals SHOULD be
-  constructed and processed to validate a set of ::BTC1 Updates:: against the
+  The type of the ::BTCR2 Beacon::  determines how these Beacon Signals SHOULD be
+  constructed and processed to validate a set of ::BTCR2 Updates:: against the
   32 bytes contained within the Beacon Signal.
 
 Beacon Signals
@@ -57,64 +65,104 @@ Beacon Signals
 
 Authorized Beacon Signal
 
-: An Authorized Beacon Signal is a ::Beacon Signal:: from a ::BTC1 Beacon:: with a ::BTC1 Beacon::
+: An Authorized Beacon Signal is a ::Beacon Signal:: from a ::BTCR2 Beacon:: with a ::BTCR2 Beacon::
   address in a then-current DID document.
 
 Authorized Beacon Signals
 
 : ::Authorized Beacon Signal::
 
+BTCR2 Update Announcement
+
+: A 32 byte SHA256 hash committing to a ::BTCR2 Update:: that has been broadcast by a ::BTCR2 Beacon:: in an 
+  ::Authorized Beacon Signal::. ::Beacon Signals:: can include one or more BTCR2 Update Announcements. 
+  How ::Beacon Signals:: include announcements is defined by the ::Beacon Type::.
+
+BTCR2 Update Announcements
+
+: ::BTCR2 Update Announcement::
+
 BTC1 Update Announcement
 
-: A 32 byte SHA256 hash committing to a ::BTC1 Update:: that has been broadcast by a ::BTC1 Beacon:: in an 
-  ::Authorized Beacon Signal::. ::Beacon Signals:: can include one or more BTC1 Update Announcements. 
-  How ::Beacon Signals:: include announcements is defined by the ::Beacon Type::.
+: ::BTCR2 Update Announcement::
 
 BTC1 Update Announcements
 
-: ::BTC1 Update Announcement::
+: ::BTCR2 Update Announcement::
+
+BTCR2 Update
+
+: A capability invocation secured using Data Integrity that invokes an authorization capability to update a specific **did:btcR2** DID document. This capability invocation Data Integrity proof secures the ::Unsecured BTCR2 Update:: document.
+
+BTCR2 Updates
+
+: ::BTCR2 Update::
 
 BTC1 Update
 
-: A capability invocation secured using Data Integrity that invokes an authorization capability to update a specific **did:btc1** DID document. This capability invocation Data Integrity proof secures the ::Unsecured BTC1 Update:: document.
+: ::BTCR2 Update::
 
 BTC1 Updates
 
-: ::BTC1 Update::
+: ::BTCR2 Update::
 
-Unsecured BTC1 Update
+Unsecured BTCR2 Update
 
-: A ::BTC1 Update:: without a proof attached to it invoking the capability to apply the update to a **did:btc1** DID document. 
-An Usecured BTC1 Update contains the JSON Patch object that defines the set of mutations to be applied to a DID document, 
+: A ::BTCR2 Update:: without a proof attached to it invoking the capability to apply the update to a **did:btcr2** DID document. 
+An Usecured BTCR2 Update contains the JSON Patch object that defines the set of mutations to be applied to a DID document, 
 along with the new version of the DID document and the source and target hashes of the DID document
 identifying the source DID document that the patch should be applied to and the target DID document that results from appliying the patch.
 
+Unsecured BTCR2 Updates
+
+: ::Unsecured BTCR2 Update::
+
+Unsecured BTC1 Update
+
+: ::Unsecured BTCR2 Update::
+
 Unsecured BTC1 Updates
 
-: ::Unsecured BTC1 Update::
+: ::Unsecured BTCR2 Update::
+
+Pending BTCR2 Update
+
+: A ::BTCR2 Update:: that has not yet been announced in an ::Authorized Beacon Signal::.
+
+Pending BTCR2 Updates
+
+: ::Pending BTCR2 Update::
 
 Pending BTC1 Update
 
-: A ::BTC1 Update:: that has not yet been announced in an ::Authorized Beacon Signal::.
+: ::Pending BTCR2 Update::
 
 Pending BTC1 Updates
 
-: ::Pending BTC1 Update::
+: ::Pending BTCR2 Update::
+
+Announced BTCR2 Update
+
+: A ::BTCR2 Update:: that has been announced in an ::Authorized Beacon Signal:: 
+which has met the specified threshold for confirmation.
+
+Announced BTCR2 Updates
+
+: ::Announced BTCR2 Update::
 
 Announced BTC1 Update
 
-: A ::BTC1 Update:: that has been announced in an ::Authorized Beacon Signal:: 
-which has met the specified threshold for confirmation.
+: ::Announced BTCR2 Update::
 
 Announced BTC1 Updates
 
-: ::Announced BTC1 Update::
+: ::Announced BTCR2 Update::
 
 Beacon Type
 
-: The type of a ::BTC1 Beacon::. The Beacon Type defines how ::BTC1 Update Announcements:: 
+: The type of a ::BTCR2 Beacon::. The Beacon Type defines how ::BTCR2 Update Announcements:: 
   are included within a ::Beacon Signal:: broadcast on the Bitcoin network. It also defines 
-  how the content committed within ::BTC1 Update Announcements:: can be verified 
+  how the content committed within ::BTCR2 Update Announcements:: can be verified 
   against the ::Beacon Signal::.
 
 Beacon Types
@@ -123,7 +171,7 @@ Beacon Types
 
 Singleton Beacon
 
-: A type of ::BTC1 Beacon:: whose ::Beacon Signals:: each contain a single ::BTC1 Update Announcement::.
+: A type of ::BTCR2 Beacon:: whose ::Beacon Signals:: each contain a single ::BTCR2 Update Announcement::.
 
 Singleton Beacons
 
@@ -131,7 +179,7 @@ Singleton Beacons
 
 Map Beacon
 
-: A type of ::BTC1 Beacon:: which aggregates multiple ::BTC1 Update Announcements::. 
+: A type of ::BTCR2 Beacon:: which aggregates multiple ::BTCR2 Update Announcements::. 
   A ::Beacon Signal:: from a Map Beacon commits to a ::Beacon Announcement Map::.
 
 Map Beacons
@@ -140,9 +188,9 @@ Map Beacons
 
 Beacon Announcement Map
 
-: A document that maps **did:btc1** identifiers to ::BTC1 Update Announcements::. 
-  This is used to distinguish which ::BTC1 Update Announcement:: applies to which 
-  **did:btc1** identifier.
+: A document that maps **did:btcr2** identifiers to ::BTCR2 Update Announcements::. 
+  This is used to distinguish which ::BTCR2 Update Announcement:: applies to which 
+  **did:btcR2** identifier.
 
 Beacon Announcement Maps
 
@@ -150,7 +198,7 @@ Beacon Announcement Maps
 
 SMT Beacon
 
-: A type of ::BTC1 Beacon:: which aggregates multiple ::BTC1 Update Announcements::.  
+: A type of ::BTCR2 Beacon:: which aggregates multiple ::BTCR2 Update Announcements::.  
   A ::Beacon Signal:: from an SMT Beacon contains the root of an optimized ::Sparse Merkle Tree::.
 
 SMT Beacons
@@ -159,7 +207,7 @@ SMT Beacons
 
 Beacon Cohort
 
-: The set of unique cryptographic keys participating in a ::BTC1 Beacon:: that are required to
+: The set of unique cryptographic keys participating in a ::BTCR2 Beacon:: that are required to
 authorize spends from the ::Beacon Address::.
 
 Beacon Cohorts
@@ -168,7 +216,7 @@ Beacon Cohorts
 
 Beacon Aggregator
 
-: The entity that coordinates the protocols of an aggregate ::BTC1 Beacon::. 
+: The entity that coordinates the protocols of an aggregate ::BTCR2 Beacon::. 
 Specifically the Create Beacon Cohort and Announce Beacon Signal protocols.
 
 Beacon Aggregators
@@ -205,9 +253,9 @@ Sparse Merkle Tree
 
   This data structure enables proofs of both inclusion and non-inclusion of data
   at a given index. The instantiation in this specification has 2^256 leaves
-  that are indexed by the SHA256 hash of a **did:btc1** identifier. The data
-  attested to at the leaves of the tree is the ::BTC1 Update:: for that
-  **did:btc1** identifier that indexed to the leaf.
+  that are indexed by the SHA256 hash of a **did:btcr2** identifier. The data
+  attested to at the leaves of the tree is the ::BTCR2 Update:: for that
+  **did:btcr2** identifier that indexed to the leaf.
 
 SMT
 
@@ -312,10 +360,10 @@ Late Publishing
 
 Offline Creation
 
-: Offline Creation refers to when a **did:btc1** identifier and corresponding
+: Offline Creation refers to when a **did:btcr2** identifier and corresponding
   initial DID document are created without requiring network interactions.
 
-**did:btc1** supports offline creation in two modes:
+**did:btcr2** supports offline creation in two modes:
 
 * Key Pair Deterministic Creation; and
 * DID Document Initiated Creation.
@@ -323,7 +371,7 @@ Offline Creation
 Sidecar
 
 : A mechanism by which data necessary for resolving a DID is provided alongside
-  the **did:btc1** identifier being resolved, rather than being retrieved through
+  the **did:btcr2** identifier being resolved, rather than being retrieved through
   open and standardized means (e.g., by retrieving from IPFS).
 
 : To explain the metaphor, a sidecar on a motorcycle brings along a second passenger
@@ -354,12 +402,12 @@ Contemporary Blockheight
 
 : The blockheight of consideration when walking the provenance of a series of DID
   updates. A DID document's contemporary time is the Signal Time of the ::Beacon Signal::
-  that announced the last ::BTC1 Update:: applied to the DID document.
+  that announced the last ::BTCR2 Update:: applied to the DID document.
 
 Intermediate DID Document
 
 : A representation of a DID document that it not yet fully conformant with the DID Core
-  specification. Intermediate DID documents for the **did:btc1** DID method are DID documents
+  specification. Intermediate DID documents for the **did:btcr2** DID method are DID documents
   whose identifier values have been replaced with a placeholder value.
 
 Intermediate DID Documents
@@ -368,7 +416,7 @@ Intermediate DID Documents
 
 Initial DID Document
 
-: The canonical, conformant version 1 of a DID document for a specific **did:btc1** identifier.
+: The canonical, conformant version 1 of a DID document for a specific **did:btcr2** identifier.
 
 Initial DID Documents
 


### PR DESCRIPTION
Updates references to did:btc1 to did:btcr2, including:
- BTC1 Beacon to BTCR2 Beacon
- BTC1 Update Announcement to BTCR2 Update Announcement
- BTC1 Update to BTCR2 Update
- Unsecured BTC1 Update to Unsecured BTCR2 Update
- Pending BTC1 Update to Pending BTCR2 Update
- Announced BTC1 Update to Announced BTCR2 Update

**_Note: Given the scope of the name change, I've left invisible link redirects in place for the BTC1 versions of the terms above so they will link to the correct BTCR2 term in the Terminology Section, just in case we miss one in this round of Spec edits. These links are visible when editing the chapter or viewing code, but not in the published Spec, and can be removed if unnecessary._**