### PR TITLE
Beacons Update to did:btcr2

### DIFF
--- a/chapters/Beacons.md
+++ b/chapters/Beacons.md
@@ -2,49 +2,49 @@
 
 ### Overview
 
-A ::BCT1 Beacon:: is an abstract mechanism, identified by a Bitcoin address, that is included as a service in a DID document to indicate to resolvers that spends from the address, called ::Beacon Signals::, should be checked for ::BTC1 Update Announcements::.
+A ::BTCR2 Beacon:: is an abstract mechanism, identified by a Bitcoin address, that is included as a service in a DID document to indicate to resolvers that spends from the address, called ::Beacon Signals::, should be checked for ::BTCR2 Update Announcements::.
 
-All ::Beacon Signals:: broadcast from a ::BTC1 Beacon:: MUST be processed as part of DID document resolution. The ::Beacon Type:: in the service defines how ::Beacon Signals:: MUST be processed.
+All ::Beacon Signals:: broadcast from a ::BTCR2 Beacon:: MUST be processed as part of DID document resolution. The ::Beacon Type:: in the service defines how ::Beacon Signals:: MUST be processed.
 
-When defining a service for a ::BTC1 Beacon:::
+When defining a service for a ::BTCR2 Beacon:::
 
-* `type` is "BTC1Beacon"
+* `type` is "BTCR2Beacon"
 * `beaconType` is one of "SingletonBeacon", "MapBeacon", or "SMTBeacon"
 * `serviceEndpoint` is a Bitcoin address represented as a URI following the [BIP21 scheme](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)
 
 How the Bitcoin address and the cryptographic material that controls it are generated is left to the implementation.
 
-**did:btc1** supports different ::Beacon Types::, with each type defining a set of algorithms for:
+**did:btcr2** supports different ::Beacon Types::, with each type defining a set of algorithms for:
 
-1. How a ::BTC1 Beacon:: can be established and added as a service to a DID document.
-1. How ::BTC1 Update Announcements:: are broadcast within ::Beacon Signals::.
+1. How a ::BTCR2 Beacon:: can be established and added as a service to a DID document.
+1. How ::BTCR2 Update Announcements:: are broadcast within ::Beacon Signals::.
 1. How a resolver processes ::Beacon Signals::, identifying, verifying, and applying the authorized mutations to a DID document for a specific DID.
 
 This is an extensible mechanism, such that in the future new ::Beacon Types:: could be added.
 
-The current, active ::BTC1 Beacons:: of a DID document are specified in the document's `service` property. By updating the DID document, a DID controller can change the set of ::BTC1 Beacons:: they use to broadcast updates to their DID document over time. Resolution of a DID MUST process signals from all ::BTC1 Beacons:: identified in the latest DID document and apply them in the order determined by the version specified by the `btc1Update`.
+The current, active ::BTCR2 Beacons:: of a DID document are specified in the document's `service` property. By updating the DID document, a DID controller can change the set of ::BTCR2 Beacons:: they use to broadcast updates to their DID document over time. Resolution of a DID MUST process signals from all ::BTCR2 Beacons:: identified in the latest DID document and apply them in the order determined by the version specified by the `btcr2Update`.
 
-All resolvers of **did:btc1** DIDs MUST support the ::Beacon Types:: defined in this specification.
+All resolvers of **did:btcr2** DIDs MUST support the ::Beacon Types:: defined in this specification.
 
 A ::Beacon Signal:: commits to and anchors in a Bitcoin block 32 bytes of information that represents one of the following:
 
-* a ::BTC1 Update Announcement::;
+* a ::BTCR2 Update Announcement::;
 * the hash of a ::Beacon Announcement Map::; or
-* the 32 bytes of an optimized ::Sparse Merkle Tree:: root, where each leaf node is deterministically selected by a **did:btc1** identifier and contains a hash associated with the **did:btc1** identifier.
+* the 32 bytes of an optimized ::Sparse Merkle Tree:: root, where each leaf node is deterministically selected by a **did:btcr2** identifier and contains a hash associated with the **did:btcr2** identifier.
 
 ### Actors
 
 Actors in signaling are as follows:
 
-* DID controller - A party that controls one or more **did:btc1** identifiers participating in a ::BTC1 Beacon::.
-* ::Beacon Cohort:: - The set of unique cryptographic keys participating in a ::BTC1 Beacon:: that make up its n-of-n MuSig2 Bitcoin address.
-* ::Beacon Aggregator:: - The entity that coordinates the protocols of an Aggregate ::BTC1 Beacon::, specifically the "Create Beacon Cohort" and "Announce Beacon Signal" protocols.
+* DID controller - A party that controls one or more **did:btcr2** identifiers participating in a ::BTCR2 Beacon::.
+* ::Beacon Cohort:: - The set of unique cryptographic keys participating in a ::BTCR2 Beacon:: that make up its n-of-n MuSig2 Bitcoin address.
+* ::Beacon Aggregator:: - The entity that coordinates the protocols of an Aggregate ::BTCR2 Beacon::, specifically the "Create Beacon Cohort" and "Announce Beacon Signal" protocols.
 * ::Beacon Participant:: - A member of a ::Beacon Cohort::, typically a DID controller, that controls cryptographic keys required to partially authorize the broadcasting of a ::Beacon Signal:: to the Bitcoin blockchain.
-* Verifier - A party verifying a **did:btc1** identifier presentation.
+* Verifier - A party verifying a **did:btcr2** identifier presentation.
 
 ### Aggregation
 
-Three types of ::BTC1 Beacons:: are defined: SingletonBeacon, MapBeacon and SMTBeacon.  Two of them, MapBeacon and SMTBeacon, support aggregation, i.e. the act of  committing to multiple ::BTC1 Update Announcements:: in a ::Beacon Signal::.
+Three types of ::BTCR2 Beacons:: are defined: SingletonBeacon, MapBeacon and SMTBeacon.  Two of them, MapBeacon and SMTBeacon, support aggregation, i.e. the act of  committing to multiple ::BTCR2 Update Announcements:: in a ::Beacon Signal::.
 
 How coordination between an aggregator and multiple ::Beacon Participants:: is managed is out of scope, but one possible mechanism is outlined in “MuSig2 3-of-3 Multisig with Coordinator Facilitation” at [MuSig2 Sequence Diagrams](https://developer.blockchaincommons.com/musig/sequence/#musig2-3-of-3-multisig-with-coordinator-facilitation).
 
@@ -60,9 +60,9 @@ When defining a ::Beacon Cohort::, the ::Beacon Aggregator:: may define the cond
 
 ### Singleton Beacon
 
-A ::Singleton Beacon:: is a ::BTC1 Beacon:: that can be used to announce commitments to a single ::BTC1 Update:: targeting a single DID document. It creates a ::Beacon Signal:: that commits to a single ::BTC1 Update Announcement::. This is typically done directly by the DID controller, as there is no ::Beacon Cohort::.
+A ::Singleton Beacon:: is a ::BTCR2 Beacon:: that can be used to announce commitments to a single ::BTCR2 Update:: targeting a single DID document. It creates a ::Beacon Signal:: that commits to a single ::BTCR2 Update Announcement::. This is typically done directly by the DID controller, as there is no ::Beacon Cohort::.
 
-If the ::BTC1 Update:: committed to by the ::BTC1 Update Announcement:: is not publicly discoverable (i.e., is not published to a ::CAS:: under its hash), the only parties that are aware of it are the DID controller and any parties provided it by the DID controller.
+If the ::BTCR2 Update:: committed to by the ::BTCR2 Update Announcement:: is not publicly discoverable (i.e., is not published to a ::CAS:: under its hash), the only parties that are aware of it are the DID controller and any parties provided it by the DID controller.
 
 The `beaconType` of the `service` for a ::Singleton Beacon:: is "SingletonBeacon".
 
@@ -83,8 +83,8 @@ Given:
     * number
 * `serviceEndpoint` - required, a Bitcoin address represented as a URI
 * One and only one of, required:
-    * `btc1Update` - the ::BTC1 Update:: whose SHA256 hash is the ::BTC1 Update Announcement:: to be broadcast in the ::Beacon Signal::
-    * `btc1UpdateAnnouncement` - the ::BTC1 Update Announcement:: to be broadcast in the ::Beacon Signal::
+    * `btcr2Update` - the ::BTCR2 Update:: whose SHA256 hash is the ::BTCR2 Update Announcement:: to be broadcast in the ::Beacon Signal::
+    * `btcr2UpdateAnnouncement` - the ::BTCR2 Update Announcement:: to be broadcast in the ::Beacon Signal::
 * `cas` - optional, one of:
     * "ipfs"
 
@@ -95,20 +95,20 @@ Construct a Bitcoin transaction that spends from the Beacon address on the selec
 1. If `cas` is defined and is not a valid value per above, raise InvalidParameter error.
 1. Set `bitcoinAddress` to the decoding of `serviceEndpoint` following BIP21.
 1. Ensure `bitcoinAddress` is funded; if not, fund this address.
-1. If `btc1UpdateAnnouncement` is not defined, set `btc1UpdateAnnouncement` to the result of passing `btc1Update` to the [JSON Canonicalization and Hash] algorithm.
-1. Initialize `spendTx` to a Bitcoin transaction that spends a transaction controlled by the `bitcoinAddress` and contains at least one transaction output. This signal output MUST have the format `[OP_RETURN, OP_PUSHBYTES32, <btc1UpdateAnnouncement>]`. If the transaction contains multiple transaction outputs, the signal output MUST be the last transaction output.
+1. If `btcr2UpdateAnnouncement` is not defined, set `btcr2UpdateAnnouncement` to the result of passing `btcr2Update` to the [JSON Canonicalization and Hash] algorithm.
+1. Initialize `spendTx` to a Bitcoin transaction that spends a transaction controlled by the `bitcoinAddress` and contains at least one transaction output. This signal output MUST have the format `[OP_RETURN, OP_PUSHBYTES32, <btcr2UpdateAnnouncement>]`. If the transaction contains multiple transaction outputs, the signal output MUST be the last transaction output.
 1. Retrieve the cryptographic material, e.g., private key or signing capability, associated with the `bitcoinAddress`. How this is done is left to the implementer.
 1. Sign the `spendTx`.
 1. Broadcast `spendTx` on the Bitcoin network defined by `network`.
-1. If `cas` and `btc1Update` are defined, publish `btc1Update` to the ::CAS:: network defined by `cas`.
+1. If `cas` and `btcr2Update` are defined, publish `btcr2Update` to the ::CAS:: network defined by `cas`.
 
 ### Map Beacon
 
-A ::Map Beacon:: creates a ::Beacon Signal:: that commits to multiple ::BTC1 Update Announcements:: through a ::Beacon Announcement Map::. To do so, it constructs a map where the key is the **did:btc1** identifier and the value is the hash of the corresponding ::BTC1 Update::, and broadcasts a SHA256 hash of the map in the ::Beacon Signal::.
+A ::Map Beacon:: creates a ::Beacon Signal:: that commits to multiple ::BTCR2 Update Announcements:: through a ::Beacon Announcement Map::. To do so, it constructs a map where the key is the **did:btcr2** identifier and the value is the hash of the corresponding ::BTCR2 Update::, and broadcasts a SHA256 hash of the map in the ::Beacon Signal::.
 
-If a ::BTC1 Update:: is not publicly discoverable (i.e., is not published to a ::CAS:: under its hash), the only parties that are aware of it are the DID controller and any parties provided it by the DID controller. However, any party that has access to or is provided the map is at least aware of the existence of all **did:btc1** identifiers in the map and the existence of their ::BTC1 Update Announcements::.
+If a ::BTCR2 Update:: is not publicly discoverable (i.e., is not published to a ::CAS:: under its hash), the only parties that are aware of it are the DID controller and any parties provided it by the DID controller. However, any party that has access to or is provided the map is at least aware of the existence of all **did:btcr2** identifiers in the map and the existence of their ::BTCR2 Update Announcements::.
 
-For a ::Map Beacon::, proof of non-inclusion of a **did:btc1** identifier is simply its absence from the map.
+For a ::Map Beacon::, proof of non-inclusion of a **did:btcr2** identifier is simply its absence from the map.
 
 The `beaconType` of the `service` for a ::Map Beacon:: is "MapBeacon".
 
@@ -203,8 +203,8 @@ sequenceDiagram
         A ->> A: Publish JSON representation of<br/>Beacon announcement map to CAS
 
         loop For each DID in unnormalized Beacon Announcement Map...
-            alt BTC1 update provided
-                A ->> A: Publish BTC1 update<br/>as file to CAS
+            alt BTCR2 update provided
+                A ->> A: Publish BTCR2 update<br/>as file to CAS
             end
         end
     end
@@ -215,21 +215,21 @@ sequenceDiagram
 Given:
 
 * `unnormalizedBeaconAnnouncementMap` - required, a map of key-value pairs consisting of:
-    * `did` - required, a unique **did:btc1** identifier (key)
+    * `did` - required, a unique **did:btcr2** identifier (key)
     * One and only one of, required (value):
-        * `btc1Update` - a ::BTC1 Update::
-        * `btc1UpdateAnnouncement` - the SHA256 hash in binary form of a ::BTC1 Update::
+        * `btcr2Update` - a ::BTCR2 Update::
+        * `btcr2UpdateAnnouncement` - the SHA256 hash in binary form of a ::BTCR2 Update::
 
 Create a ::Beacon Announcement Map:: as follows:
 
 1. If `unnormalizedBeaconAnnouncementMap` contains a duplicate `did`, raise InvalidParameter error.
 1. Create empty `beaconAnnouncementMap`.
 1. For each `did` in `unnormalizedBeaconAnnouncementMap`:
-   1. If the value is a ::BTC1 Update:::
-      1. Set `hashBytes` to the result of passing `btc1Update` to the [JSON Canonicalization and Hash] algorithm.
+   1. If the value is a ::BTCR2 Update:::
+      1. Set `hashBytes` to the result of passing `btcr2Update` to the [JSON Canonicalization and Hash] algorithm.
       1. Set `hashString` to the hexadecimal string representation of `hashBytes`.
    1. If the value is a SHA256 hash in binary form:
-       1. Set `hashString` to the hexadecimal string representation of `btc1UpdateAnnouncement`.
+       1. Set `hashString` to the hexadecimal string representation of `btcr2UpdateAnnouncement`.
    1. Add `did` (key) and `hashString` (value) to `beaconAnnouncementMap`.
 
 ##### Construct Unsigned Beacon Signal
@@ -287,13 +287,13 @@ Spend the transaction and publish to ::CAS:::
 1. Broadcast `spendTx` on the Bitcoin network.
 1. If `cas` is defined:
    1. Publish JSON representation of `beaconAnnouncementMap` to the ::CAS:: network defined by `cas`.
-   1. For each `did` with a `btc1Update` in `unnormalizedBeaconAnnouncementMap`, publish `btc1Update` to the ::CAS:: network defined by `cas`.
+   1. For each `did` with a `btcr2Update` in `unnormalizedBeaconAnnouncementMap`, publish `btcr2Update` to the ::CAS:: network defined by `cas`.
 
 ### SMT Beacon
 
-An ::SMT Beacon:: creates a ::Beacon Signal:: that commits to multiple ::BTC1 Update Announcements::, each identified by a **did:btc1** identifier. To do so, it constructs an optimized ::Sparse Merkle Tree:: as defined in [Appendix - Optimized Sparse Merkle Tree Implementation] and publishes the Merkle root.
+An ::SMT Beacon:: creates a ::Beacon Signal:: that commits to multiple ::BTCR2 Update Announcements::, each identified by a **did:btcr2** identifier. To do so, it constructs an optimized ::Sparse Merkle Tree:: as defined in [Appendix - Optimized Sparse Merkle Tree Implementation] and publishes the Merkle root.
 
-An ::SMT Beacon:: provides maximum privacy for the DID controller, as the DID controller never has to reveal their DIDs or ::BTC1 Updates:: to the aggregator. This introduces a small risk, as the DID controller is not required to prove control over a DID in order to participate.
+An ::SMT Beacon:: provides maximum privacy for the DID controller, as the DID controller never has to reveal their DIDs or ::BTCR2 Updates:: to the aggregator. This introduces a small risk, as the DID controller is not required to prove control over a DID in order to participate.
 
 The `beaconType` of the `service` for an ::SMT Beacon:: is "SMTBeacon".
 
@@ -352,7 +352,7 @@ sequenceDiagram
     loop Until signal conditions met...
         R ->> R: Calculate index = hash(DID)
         R ->> R: Generate nonce
-        R ->> R: Calculate update = hash(hash(nonce) +<br/>hash(BTC1 Update))
+        R ->> R: Calculate update = hash(hash(nonce) +<br/>hash(BTCR2 Update))
         R ->> A: Send index and update
         A ->> A: Validate index against Beacon<br/>participant's authorized list
         A ->> A: Calculate value = hash(index +<br/>update)
@@ -468,14 +468,14 @@ Validate the proof paths map and the unsigned ::Beacon Signal:::
    1. Set `index` to `hash(did)`.
    1. Set `path` to the value at `index` and remove it from the map.
    1. If `path` is undefined, raise InvalidParameter error.
-   1. Extract the current `nonce` and `btc1Update` for `did` from local storage.
-   1. If `btc1Update` is defined, set `btc1UpdateAnnouncement` to the result of passing `btc1Update` to the [JSON Canonicalization and Hash] algorithm and set `hashBytes` to `hash(index + hash(hash(nonce) + btc1UpdateAnnouncement))`, otherwise set `hashBytes` to `hash(index + hash(hash(nonce)))`.
+   1. Extract the current `nonce` and `btcr2Update` for `did` from local storage.
+   1. If `btcr2Update` is defined, set `btcr2UpdateAnnouncement` to the result of passing `btcr2Update` to the [JSON Canonicalization and Hash] algorithm and set `hashBytes` to `hash(index + hash(hash(nonce) + btcr2UpdateAnnouncement))`, otherwise set `hashBytes` to `hash(index + hash(hash(nonce)))`.
    1. For each `step` in `path`:
       1. Validate that `step` has a single key-value pair.
       1. Extract `key` and `value` from `step`.
       1. If `key` is `"left"`, set `hashBytes` to `hash(value + hashBytes)`; otherwise, if `key` is `"right"`, set `hashBytes` to `hash(hashBytes + value)`; otherwise, raise InvalidParameter error.
    1. Validate that the last transaction output of `unsignedSpendTx` is `[OP_RETURN, OP_PUSHBYTES32, <hashBytes>]`.
-   1. If `btc1UpdateAnnouncement` is defined, construct as `smtProof` the object `{id: <hashString>, nonce: <nonce>, updateId: <btc1UpdateHashString>, path: <path>}`, otherwise construct as `smtProof` the object `{id: <hashString>, nonce: <nonce>, path: <path>}`, where `hashString` is the hexadecimal string representation of `hashBytes` and `btc1UpdateHashString` is the hexadecimal string representation of `btc1UpdateAnnouncement`.
+   1. If `btcr2UpdateAnnouncement` is defined, construct as `smtProof` the object `{id: <hashString>, nonce: <nonce>, updateId: <btcr2UpdateHashString>, path: <path>}`, otherwise construct as `smtProof` the object `{id: <hashString>, nonce: <nonce>, path: <path>}`, where `hashString` is the hexadecimal string representation of `hashBytes` and `btcr2UpdateHashString` is the hexadecimal string representation of `btcr2UpdateAnnouncement`.
    1. Store `smtProof` for later presentation to verifiers.
 1. If `pathsMap` is not empty, raise InvalidParameter error.
 
@@ -494,11 +494,11 @@ Spend the transaction:
 
 Given:
 
-* `did` - required, the **did:btc1** identifier whose signals are to be processed.
+* `did` - required, the **did:btcr2** identifier whose signals are to be processed.
 * `sidecarDocuments` - required, array of documents required for resolution not stored on a ::CAS::,including:
-  * Initial DID document, if `did` was constructed with `idType` of "external" (`did` has the form "did:btc1:x1...").
-  * Map documents for ::BTC1 Beacons:: with services of `beaconType` "MapBeacon".
-  * ::BTC1 Updates:: for each ::BTC1 Update Announcement::.
+  * Initial DID document, if `did` was constructed with `idType` of "external" (`did` has the form "did:btcr2:x1...").
+  * Map documents for ::BTCR2 Beacons:: with services of `beaconType` "MapBeacon".
+  * ::BTCR2 Updates:: for each ::BTCR2 Update Announcement::.
 * `smtProofs` - required for services of `beaconType` "SMTBeacon", array of ::SMT:: proofs of inclusion or non-inclusion.
 * `cas` - optional, one of:
     * "ipfs"
@@ -524,30 +524,30 @@ Process the ::Beacon Signals:: to reconstruct the DID document:
    1. Update placeholder values in `didDocument` with `did` as required.
    1. If `didDocument` is not a valid DID document, raise InvalidDidUpdate error.
 1. Until terminated:
-   1. Set `btc1Update` to null.
-   1. For each `service` in `didDocument.service` where `service.type` is "BTC1Beacon":
+   1. Set `btcr2Update` to null.
+   1. For each `service` in `didDocument.service` where `service.type` is "BTCR2Beacon":
       1. Get the next transaction from the Bitcoin address at `service.serviceEndpoint`.
       1. If `targetVersionTime` is defined and is less than the transaction time, skip to next `service`.
       1. If the last output transaction is not of the form `[OP_RETURN, OP_PUSHBYTES32, <hashBytes>]`, skip to next `service`.
       1. Extract `hashBytes` from the last output transaction.
       1. If `service.beaconType` is not "SingletonBeacon", "MapBeacon", or "SMTBeacon", raise InvalidParameter error.
-      1. If `service.beaconType` is "SingletonBeacon", set `tempBtc1Update` to the result of [Process Singleton Beacon Signal].
-      1. If `service.beaconType` is "MapBeacon", set `tempBtc1Update` to the result of [Process Map Beacon Signal].
-      1. If `service.beaconType` is "SMTBeacon", set `tempBtc1Update` to the result of [Process SMT Beacon Signal].
-      1. If `tempBtc1Update` is null, skip to next `service`.
-      1. Set `tempDidDocument` to transformation of `didDocument` with `tempBtc1Update`.
+      1. If `service.beaconType` is "SingletonBeacon", set `tempBtcr2Update` to the result of [Process Singleton Beacon Signal].
+      1. If `service.beaconType` is "MapBeacon", set `tempBtcr2Update` to the result of [Process Map Beacon Signal].
+      1. If `service.beaconType` is "SMTBeacon", set `tempBtcr2Update` to the result of [Process SMT Beacon Signal].
+      1. If `tempBtcr2Update` is null, skip to next `service`.
+      1. Set `tempDidDocument` to transformation of `didDocument` with `tempBtcr2Update`.
       1. If `tempDidDocument.versionId` ≠ `didDocument.versionId + 1`, skip to next `service`.
-      1. If `btc1Update` is not null and `tempBtc1Update` ≠ `btc1Update`, raise InvalidDidUpdate error.
-      1. Set `btc1Update` to `tempBtc1Update`. 
-   1. If `btc1Update` is null, terminate.
-   1. Set `didDocument` to transformation of `didDocument` with `btc1Update`.
+      1. If `btcr2Update` is not null and `tempBtcr2Update` ≠ `btcr2Update`, raise InvalidDidUpdate error.
+      1. Set `btcr2Update` to `tempBtcr2Update`. 
+   1. If `btcr2Update` is null, terminate.
+   1. Set `didDocument` to transformation of `didDocument` with `btcr2Update`.
    1. If `didDocument` is not a valid DID document, raise InvalidDidUpdate error.
-   1. If `didDocument.id` is not the same as the **did:btc1** identifier, raise InvalidDidUpdate error.
-   1. If `didDocument` has no ::BTC1 Beacon:: service types (i.e., no services where `service.type` is "BTC1Beacon"), raise InvalidDidUpdate error.
+   1. If `didDocument.id` is not the same as the **did:btcr2** identifier, raise InvalidDidUpdate error.
+   1. If `didDocument` has no ::BTCR2 Beacon:: service types (i.e., no services where `service.type` is "BTCR2Beacon"), raise InvalidDidUpdate error.
    1. If `targetVersionId` is defined and `didDocument.versionId` = `targetVersionId`, terminate.
 1. If `targetVersionId` is defined and `didDocument.versionId` ≠ `targetVersionId`, raise InvalidDidUpdate error.
 1. If `targetVersionId` is not defined:
-       1. For each `service` in `didDocument.service` where `service.type` is "BTC1Beacon":
+       1. For each `service` in `didDocument.service` where `service.type` is "BTCR2Beacon":
       1. Get the next transaction from the Bitcoin address at `service.serviceEndpoint`.
       1. If `targetVersionTime` is defined and is less than the transaction time, skip to next `service`.
       1. If the last output transaction is of the form `[OP_RETURN, OP_PUSHBYTES32, <hashBytes>]`, raise InvalidDidUpdate error.
@@ -556,10 +556,10 @@ Process the ::Beacon Signals:: to reconstruct the DID document:
 #### Process Singleton Beacon Signal
 
 1. Set `id` to the hexadecimal string representation of `hashBytes`.
-1. Get `btc1Update` from `sidecarDocumentsMap` by its `id` if available, or from ::CAS:: by its `id` if not and `cas` is defined.
-1. If `btc1Update` is undefined, raise InvalidDidUpdate error.
-1. Set `btc1Update`
-1. Return `btc1Update`.
+1. Get `btcr2Update` from `sidecarDocumentsMap` by its `id` if available, or from ::CAS:: by its `id` if not and `cas` is defined.
+1. If `btcr2Update` is undefined, raise InvalidDidUpdate error.
+1. Set `btcr2Update`
+1. Return `btcr2Update`.
 
 > **NOTE**: The act of retrieving from `sidecarDocumentsMap` or ::CAS:: validates the document hash.
 
@@ -570,9 +570,9 @@ Process the ::Beacon Signals:: to reconstruct the DID document:
 1. If `map` is undefined, raise InvalidDidUpdate error.
 1. Set `updateId` to the value of `map.<did>`.
 1. If `updateId` is undefined, return null.
-1. Get `btc1Update` from `sidecarDocumentsMap` by its `updateId` if available, or from ::CAS:: by its `updateId` if not and `cas` is defined.
-1. If `btc1Update` is undefined, raise InvalidDidUpdate error.
-1. Return `btc1Update`.
+1. Get `btcr2Update` from `sidecarDocumentsMap` by its `updateId` if available, or from ::CAS:: by its `updateId` if not and `cas` is defined.
+1. If `btcr2Update` is undefined, raise InvalidDidUpdate error.
+1. Return `btcr2Update`.
 
 > **NOTE**: The act of retrieving from `sidecarDocumentsMap` or ::CAS:: validates the document hash.
 
@@ -584,15 +584,15 @@ Process the ::Beacon Signals:: to reconstruct the DID document:
 1. Set `index` to `hash(did)`.
 1. Set `nonce` to the value of `smtProof.nonce`.
 1. Set `updateId` to the value of `smtProof.updateId`.
-1. If `updateId` is defined, set `btc1UpdateAnnouncement` to the binary representation of `updateId` and set `verifyHashBytes` to `hash(index + hash(hash(nonce) + btc1UpdateAnnouncement))`, otherwise set `verifyHashBytes` to `hash(index + hash(hash(nonce)))`.
+1. If `updateId` is defined, set `btcr2UpdateAnnouncement` to the binary representation of `updateId` and set `verifyHashBytes` to `hash(index + hash(hash(nonce) + btcr2UpdateAnnouncement))`, otherwise set `verifyHashBytes` to `hash(index + hash(hash(nonce)))`.
 1. For each `step` in `smtProof.path`:
    1. Validate that `step` has a single key-value pair.
    1. Extract `key` and `value` from `step`.
    1. If `key` is `"left"`, set `verifyHashBytes` to `hash(value + verifyHashBytes)`; otherwise, if `key` is `"right"`, set `verifyHashBytes` to `hash(verifyHashBytes + value)`; otherwise, raise InvalidDidUpdate error.
 1. If `verifyHashBytes` ≠ `hashBytes`, raise InvalidDidUpdate error.
 1. If `updateId` is undefined, return null.
-1. Get `btc1Update` from `sidecarDocumentsMap` by its `updateId` if available, or from ::CAS:: by its `updateId` if not and `cas` is defined.
-1. If `btc1Update` is undefined, raise InvalidDidUpdate error.
-1. Return `btc1Update`.
+1. Get `btcr2Update` from `sidecarDocumentsMap` by its `updateId` if available, or from ::CAS:: by its `updateId` if not and `cas` is defined.
+1. If `btcr2Update` is undefined, raise InvalidDidUpdate error.
+1. Return `btcr2Update`.
 
 > **NOTE**: The act of retrieving from `sidecarDocumentsMap` validates the document hash.


### PR DESCRIPTION
Updates reference to did:btc1 to did:btcr2, including:
- BTC1 Beacon to BTCR2 Beacon
- BTC1 Update Announcement to BTCR2 Update Announcement
- BTC1 Update to BTCR2 Update
- Unsecured BTC1 Update to Unsecured BTCR2 Update
- Pending BTC1 Update to Pending BTCR2 Update
- Announced BTC1 Update to Announced BTCR2 Update