### PR TITLE
Additions for the Update chapter

### DIFF
--- a/mdbook/src/algorithms.md
+++ b/mdbook/src/algorithms.md
@@ -162,9 +162,7 @@ See the "Resolve" operation for details.
 
 ## Prior "Algorithms" that we need to either rule out or flesh out
 
-### Algo 15. Create Singleton Beacon Service
 ### Algo 16. Join Cohort and Establish Aggregate Beacon Service
-### Algo 17. Create Canonical BTCR2 Update
 ### Algo 18. Create & Announce Singleton Beacon Signal
 ### Algo 19. Advertise Update Opportunity (Aggregator)
 ### Algo 20. Prepare & Submit Opportunity Response (Participant)

--- a/mdbook/src/data-structures.md
+++ b/mdbook/src/data-structures.md
@@ -152,13 +152,11 @@ A [BTCR2 Signed Update] is a Map data structure with the same properties as
 ) }}
 
 
-## Data Integrity Proof { #data-integrity-proof }
+## Data Integrity Config { #data-integrity-config }
 
-A Data Integrity {{#cite VC-DATA-INTEGRITY}} proof with the `proofPurpose` set to
-`"capabilityInvocation"`. This proof MUST be a valid invocation of the capability to update the DID
-document of the **did:btcr2** identifier being resolved.
+A Data Integrity {{#cite VC-DATA-INTEGRITY}} proof with the `proofPurpose` set to `"capabilityInvocation"` and `proofValue` omitted.
 
-The following properties MUST be included in the Data Integrity proof:
+The following properties MUST be included in the Data Integrity Config:
 
 - `@context`: A context array containing the follow context URLs:
   - `"https://w3id.org/security/v2"`
@@ -169,10 +167,18 @@ The following properties MUST be included in the Data Integrity proof:
 - `cryptosuite`: The string `"bip340-jcs-2025"`.
 - `verificationMethod`: A valid `verificationMethod` reference that exists in the most recent DID document.
 - `proofPurpose`: The string `"capabilityInvocation"`.
-- `capability`: A URN of the following format: `urn:zcap:root:${encodeURIComponent(DID)}`.
+- `capability`: A URN of the following format: `urn:zcap:root:${encodeURIComponent(did)}`.
 - `capabilityAction`: A string declaring the action required for the capability invocation. The
   string MUST be set to `"Write"`.
-- `proofValue`: MUST be a detached Schnorr signature produced according to Schnorr Signatures for secp256k1 {{#cite BIP340}}, encoded using the `"base64url"` {{#cite RFC4648}} encoding.
+
+
+## Data Integrity Proof { #data-integrity-proof }
+
+A [Data Integrity Proof] with the `proofPurpose` set to `"capabilityInvocation"`. This proof MUST be a valid invocation of the capability to update a **did:btcr2** DID document.
+
+This data structure is a Map data structure with the same properties as [Data Integrity Config (data structure)] and one additional property:
+
+- `proofValue`: MUST be a detached Schnorr signature produced according to Schnorr Signatures for secp256k1 {{#cite BIP340}}, as a Multibase `"base-58-btc"` {{#cite CID}} encoded string.
 
 {% set hide_text = `` %}
 {% set ex_di_proof =
@@ -228,11 +234,11 @@ The [Sidecar Data] contains optional properties:
 
 A [SMT Proof] data structure contains the following properties:
 
-- `id`: hash of the root node.
-- `nonce`: OPTIONAL 256-bit nonce generated for each update.
-- `updateId`: hash of the [BTCR2 Signed Update].
-- `path`: array of Hashes representing the sibling SMT Nodes from the root to the leaf containing the hash of the [BTCR2 Signed Update] or the "zero identity".
-- `collapsed`: bitmap of zero nodes within the path (see: [collapsed leaves](https://github.com/hoytech/quadrable#collapsed-leaves)).
+- `id`: SHA-256 hash of the root node.
+- `nonce`: OPTIONAL 256-bit nonce generated for each update. MUST be encoded as a string using the `"base64url"` {{#cite RFC4648}} encoding.
+- `updateId`: The OPTIONAL [BTCR2 Signed Update (data structure)] hashed with the [JSON Document Hashing] algorithm.
+- `path`: Array of SHA-256 hashes representing the sibling [SMT] nodes from the root to the leaf containing the SHA-256 hash of the [BTCR2 Signed Update] or the "zero identity".
+- `collapsed`: Bitmap of zero nodes within the path (see: [collapsed leaves](https://github.com/hoytech/quadrable#collapsed-leaves)).
 
 
 ## Resolution Options { #resolution-options }
@@ -269,9 +275,7 @@ Document metadata MAY contain the following properties:
 
 ## CAS Announcement { #cas-announcement }
 
-A data structure that maps DIDs to hashed [BTCR2 Signed Updates][BTCR2 Signed Update]. It MUST be
-hashed with the [JSON Document Hashing] algorithm to produce the [Signal Bytes] for a
-[Beacon Signal]. The concrete representation of this data structure will be published to a [CAS].
+A data structure that maps DIDs to [BTCR2 Signed Update] hashes. All [BTCR2 Signed Updates (data structure)][BTCR2 Signed Update (data structure)] MUST be hashed with the [JSON Document Hashing] algorithm. The concrete representation of this data structure will be published to a [CAS].
 
 {% set hide_text = `` %}
 {% set ex_cas_announcement_data =

--- a/mdbook/src/example-data/data-integrity-config.hbs
+++ b/mdbook/src/example-data/data-integrity-config.hbs
@@ -1,0 +1,14 @@
+{
+  "@context": [
+    "https://w3id.org/security/v2",
+    "https://w3id.org/zcap/v1",
+    "https://w3id.org/json-ld-patch/v1",
+    "https://btcr2.dev/context/v1"
+  ],
+  "type": "DataIntegrityProof",
+  "cryptosuite": "bip340-jcs-2025",
+  "verificationMethod": "{{ verification-method }}",
+  "proofPurpose": "capabilityInvocation",
+  "capability": "{{ capability }}",
+  "capabilityAction": "Write"
+}

--- a/mdbook/src/includes/data-structures-links.tera
+++ b/mdbook/src/includes/data-structures-links.tera
@@ -3,6 +3,7 @@
 [Initial document (data structure)]: {{ root }}data-structures.md#initial-document
 [BTCR2 Unsigned Update (data structure)]: {{ root }}data-structures.md#btcr2-unsigned-update
 [BTCR2 Signed Update (data structure)]: {{ root }}data-structures.md#btcr2-signed-update
+[Data Integrity Config (data structure)]: {{ root }}data-structures.md#data-integrity-config
 [Data Integrity Proof (data structure)]: {{ root }}data-structures.md#data-integrity-proof
 [Sidecar Data (data structure)]: {{ root }}data-structures.md#sidecar-data
 [SMT Proof (data structure)]: {{ root }}data-structures.md#smt-proof

--- a/mdbook/src/operations/resolve.md
+++ b/mdbook/src/operations/resolve.md
@@ -179,7 +179,7 @@ Fill the [Initial DID Document] template below with the required template variab
 addresses MUST use the Bitcoin URI Scheme {{#cite BIP321}}.
 
 * `did`: The `did`.
-* `public-key-multikey`: Multikey format representation {{#cite BIP340-Cryptosuite}} of the public key.
+* `public-key-multikey`: Public key as a Multibase `"base-58-btc"` {{#cite CID}} encoded string.
 * `p2pkh-bitcoin-address`: A Pay-to-Public-Key-Hash (P2PKH) Bitcoin address produced from the public key.
 * `p2wpkh-bitcoin-address`: A Pay-to-Witness-Public-Key-Hash (P2WPKH) Bitcoin address produced from the public key.
 * `p2tr-bitcoin-address`: A Pay-to-Taproot (P2PKH) Bitcoin address produced from the public key.

--- a/mdbook/src/references.bib
+++ b/mdbook/src/references.bib
@@ -42,6 +42,17 @@
   abstract = {This document defines an improved variant of Bech32 called Bech32m, and amends BIP173 to use Bech32m for native segregated witness outputs of version 1 and later. Bech32 remains in use for segregated witness outputs of version 0.}
 }
 
+@misc{CID,
+  title = {Controlled Identifiers v1.0},
+  author = {Dave Longley, Manu Sporny, Markus Sabadello, Drummond Reed, Orie Steele, Christopher Allen},
+  howpublished = {Online},
+  year = {2025},
+  month = {May},
+  url = {https://www.w3.org/TR/cid-1.0/},
+  note = {CID},
+  abstract = {A controlled identifier document contains cryptographic material and lists service endpoints for the purposes of verifying cryptographic proofs from, and interacting with, the controller of an identifier.}
+}
+
 @misc{DID-CORE,
   title = {Decentralized Identifiers (DIDs) v1.1},
   author = {Manu Sporny, Dave Longley, Markus Sabadello, Drummond Reed, Orie Steele, Christopher Allen},


### PR DESCRIPTION
Splits update creation into "Unsigned" and "Signed" sub-sections.

Adds missing assertions required when signing the update.

Adds a new "Data Integrity Config" data structure which is defined as a Data Integrity Proof with the `proofValue` property omitted. The data structure is created with a template and passed to the `cryptosuite.createProof` method to produce `update.proof`.

Adds clarity around SHA-256 hashes described in the Data Structures chapter.

Fixes the encoding used on public keys and signatures. (The encoding is required by `BIP340-Cryptosuite` but is specified by `CID`.)

Removes Algos that are now covered:

* Algo 15: I guess this just shows an example of updating a DID document. There is no reason to specify an example as an algorithm.
* Algo 17: Covered in Updates chapter.

Remaining Algos are for update announcements (which are TBD).