### PR TITLE
CI: Add write permissions, per docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: github pages
 
+permissions:
+  contents: write
+  pages: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
- From https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-first-deployment-with-github_token
- See also: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

This is an attempt to fix [the deployment failure](https://github.com/dcdpr/did-btcr2/actions/runs/20444135864/job/58743762526). We won't know if it works until after this is committed to the main branch. :(