### PR TITLE
Create Section Edits

### DIFF
--- a/src/operations/create.md
+++ b/src/operations/create.md
@@ -17,19 +17,19 @@ and service endpoints.
 ## Process
 
 A **did:btcr2** identifier encodes a few pieces of information: an indicator
-for a specific Bitcoin network and a collection of [Genesis Bytes]. A
-specification version number is also included. These three values are
+for a specific Bitcoin network, a collection of [Genesis Bytes], and a
+specification version number. These three values are
 encoded with the [DID-BTCR2 Identifier Encoding] algorithm.
 
-The [Genesis Bytes] can be created in two ways: from an secp256k1 public key
+The [Genesis Bytes] can be created in two ways: from a secp256k1 public key
 or from a [Genesis Document].
 
 ## secp256k1 Public Key
 
-An secp256k1 public key can be used as the [Genesis Bytes]. The key MUST be
-in its compressed SEC format: a 33-byte representation consisting of a
-single prefix byte (`0x02` or `0x03`) followed by the 32-byte x-coordinate of
-the elliptic curve point.
+A secp256k1 public key can be used as the [Genesis Bytes]. The key MUST be
+in its compressed Standards for Efficient Cryptography (SEC) format: a 33-byte 
+representation consisting of asingle prefix byte (`0x02` or `0x03`) followed by 
+the 32-byte x-coordinate ofthe elliptic curve point.
 Reference Section 2.3.3 in SEC 1: Elliptic Curve Cryptography {{#cite SEC}}.
 
 ## Genesis Document Hash


### PR DESCRIPTION
Slight adjustment to the wording in the first Process sentence; changed "an" to "a" for secp256k1 public key; added Standards for Efficient Cryptography for first SEC usage in section.