### PR TITLE
Clarify "return" language in Process updates Array (resolves #299)

### DIFF
--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -36,7 +36,7 @@ The resolver:
 2. Repeats the following loop:
     * [Process Beacon Signals](#process-beacon-signals) to populate `updates` from the beacon services in `current_document`.
     * [Process `updates` Array](#process-updates) to apply updates to `current_document` and refresh `block_confirmations`.
-    * Stops when processing updates returns early with a resolved `didDocument` or an error occurs.
+    * The loop terminates when processing updates resolves `didDocument` or an error occurs.
 
 The resolver returns:
 
@@ -141,17 +141,17 @@ Treat [Signal Bytes] as `smt_root`. Look up `smt_root` in `smt_lookup_table` to 
 
 ## Process `updates` Array { #process-updates }
 
-Return `current_document` as the resolved `didDocument` if `updates` is empty.
+Resolve `current_document` as `didDocument` if `updates` is empty.
 
 Otherwise:
 
 1. Sort `updates` by [BTCR2 Signed Update (data structure)] `targetVersionId` (ascending) with the tuple's block height as a tiebreaker. Take the first tuple.
 2. Set `block_confirmations` to the tuple's block confirmations.
-3. If `resolutionOptions.versionTime` is provided and the tuple's block time is more recent, return `current_document` as the resolved `didDocument`.
+3. If `resolutionOptions.versionTime` is provided and the tuple's block time is more recent, resolve `current_document` as `didDocument`.
 4. Set `update` to the tuple's [BTCR2 Signed Update (data structure)] and [check `update.targetVersionId`](#check-update-version).
 5. Increment `current_version_id`.
-6. If `current_version_id` is greater than or equal to the integer form of `resolutionOptions.versionId`, return `current_document`.
-7. If `current_document.deactivated` is `true`, return `current_document`.
+6. If `current_version_id` is greater than or equal to the integer form of `resolutionOptions.versionId`, resolve `current_document` as `didDocument`.
+7. If `current_document.deactivated` is `true`, resolve `current_document` as `didDocument`.
 
 
 ### Check `update.targetVersionId` { #check-update-version }


### PR DESCRIPTION
* Previous wording reads like early exit
* New language clarifies statements as loop termination conditions that
* Replace "return" with "resolve" in the Process `updates` Array section
* Remove "returns early" from the loop description