### PR TITLE
Remove "controller" property from DID document template

### DIFF
--- a/src/example-data/key-based-initial-did-document-template.hbs
+++ b/src/example-data/key-based-initial-did-document-template.hbs
@@ -4,9 +4,6 @@
     "https://btcr2.dev/context/v1"
   ],
   "id": "{{did}}",
-  "controller": [
-    "{{did}}"
-  ],
   "verificationMethod": [
     {
       "id": "{{did}}#initialKey",


### PR DESCRIPTION
I know there has been some back and forth on this in the past, e.g. https://github.com/dcdpr/did-btcr2/issues/78, https://github.com/dcdpr/did-btcr2/issues/206.

The current template has a "controller" property:
https://dcdpr.github.io/did-btcr2/operations/resolve.html#initial-did-document-template-panel-show

But the latest test vectors don't have it, e.g.:
https://github.com/dcdpr/did-btcr2-test-suite/blob/btcr2-v0.1/regtest/k1/qgpr45ch/resolve/output.json

My understanding is that the latest thinking was that the "controller" property isn't needed, so here's a PR to fix that.