### PR TITLE
Fix proof of non-inclusion in SMT Proof Verification algorithm

### DIFF
--- a/src/algorithms.md
+++ b/src/algorithms.md
@@ -136,9 +136,10 @@ Construct a hashed-zero cache. Two zero leaves are hashed together by concatenat
 ~~~rust
 let cachedZero = [];
 let z = 0;
-for i in 0..=255 {
+
+for n in 0..=255 {
   z = hash(concat(z, z));
-  cachedZero[i] = z;
+  cachedZero[n] = z;
 }
 ~~~
 ` %}
@@ -153,7 +154,7 @@ hide_label="Hide"
 ) }}
 
 
-The [SMT Proof (data structure)] is verified by walking the tree starting from the leaf node value, given by `hash(hash(proof.nonce) + proof.updateId)`, to the root `proof.id`. Walking the tree means hashing sibling hashes from `proof.hashes` concatenated with a candidate hash to construct each node value. Each bit within the leaf node index (given by `hash(did)`) informs the algorithm which side of the concatenation operation the sibling hash belongs on: 0 for left, 1 for right.
+The [SMT Proof (data structure)] is verified by walking the tree starting from the leaf node value --- given by `hash(hash(proof.nonce) + proof.updateId)` for update inclusion or `hash(hash(proof.nonce))` for non-inclusion --- to the root `proof.id`. Walking the tree means hashing sibling hashes from `proof.hashes` concatenated with a candidate hash to construct each node value. Each bit within the leaf node index (given by `hash(did)`) informs the algorithm which side of the concatenation operation the sibling hash belongs on: 0 for left, 1 for right.
 
 The tree is "optimized" by collapsing empty nodes. (See [Appendix: Optimized Sparse Merkle Tree Implementation] for definition of "optimized".) Each bit within `proof.collapsed` informs the algorithm whether to take the next sibling hash from `proof.hashes` (0) or use a hashed zero from the current height of the tree (1).
 
@@ -163,18 +164,24 @@ The last step is asserting that the computed candidate hash is equivalent to `pr
 {% set pseudocode_smt_proof_verification =
 `
 ~~~rust
-let candidateHash = hash(concat(hash(proof.nonce), proof.updateId))
-let index = hash(did)
+let candidateHash = if let Some(updateId) = proof.updateId {
+  hash(concat(hash(proof.nonce), updateId))
+} else {
+  hash(hash(proof.nonce))
+};
+
+let index = hash(did);
+
 for n in 0..=255 {
   let i = 255 - n;
 
-  let siblingHash = if proof.collapsed[i] == 1 {
+  let siblingHash = if proof.collapsed.bitAt(i) == 1 {
     cachedZero[n]
   } else {
     proof.hashes.pop_front()
   };
 
-  if index[i] == 1 {
+  if index.bitAt(i) == 1 {
     candidateHash = hash(concat(siblingHash, candidateHash));
   } else {
     candidateHash = hash(concat(candidateHash, siblingHash));


### PR DESCRIPTION
This was discussed in https://github.com/dcdpr/did-btcr2/pull/319#issuecomment-4723580108

Adds support for non-inclusion proofs to the algorithm description and pseudocode. Fixes some minor syntactic errors (missing semicolons) and slightly improves readability with whitespace.

The `cachedZero` pseudocode was also updated to use `n` as the index variable name to better match the longer pseudocode.

And today I learned that mdBook's `smart-punctuation` option allows rendering em dashes with triple-hyphens. https://rust-lang.github.io/mdBook/format/markdown.html#smart-punctuation Em dashes looked better than parentheses and commas.