### PR TITLE
Only increment current_version_id when an update is applied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 __pycache__
 venv
 book/
+.claude/

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -189,7 +189,9 @@ Verify that `current_document` conforms to DID Core v1.1 {{#cite DID-CORE}} and 
 
 Hash the patched `current_document` with the [JSON Document Hashing] algorithm. Raise an [`INVALID_DID_UPDATE`] error if the result does not match the decoded `update.targetHash`.
 
-Create `unsigned_update` by removing the `proof` property from `update`, hash it with the [JSON Document Hashing] algorithm, and append the hash to `update_hash_history`. Increment `current_version_id`.
+Create `unsigned_update` by removing the `proof` property from `update`, hash it with the [JSON Document Hashing] algorithm, and append the hash to `update_hash_history`. 
+
+Increment `current_version_id`.
 
 
 ### Check `update.proof` { #check-update-proof }

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -152,9 +152,8 @@ Otherwise:
 2. Set `block_confirmations` to the tuple's block confirmations.
 3. If `resolutionOptions.versionTime` is provided and the tuple's block time is more recent, resolve `current_document` as `didDocument`.
 4. Set `update` to the tuple's [BTCR2 Signed Update (data structure)] and [check `update.targetVersionId`](#check-update-version).
-5. Increment `current_version_id`.
-6. If `current_version_id` is greater than or equal to the integer form of `resolutionOptions.versionId`, resolve `current_document` as `didDocument`.
-7. If `current_document.deactivated` is `true`, resolve `current_document` as `didDocument`.
+5. If `current_version_id` is greater than or equal to the integer form of `resolutionOptions.versionId`, resolve `current_document` as `didDocument`.
+6. If `current_document.deactivated` is `true`, resolve `current_document` as `didDocument`.
 
 
 ### Check `update.targetVersionId` { #check-update-version }
@@ -188,7 +187,7 @@ Verify that `current_document` conforms to DID Core v1.1 {{#cite DID-CORE}} and 
 
 Hash the patched `current_document` with the [JSON Document Hashing] algorithm. Raise an [`INVALID_DID_UPDATE`] error if the result does not match the decoded `update.targetHash`.
 
-Create `unsigned_update` by removing the `proof` property from `update`, hash it with the [JSON Document Hashing] algorithm, and append the hash to `update_hash_history`.
+Create `unsigned_update` by removing the `proof` property from `update`, hash it with the [JSON Document Hashing] algorithm, and append the hash to `update_hash_history`. Increment `current_version_id`.
 
 
 ### Check `update.proof` { #check-update-proof }

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -172,6 +172,8 @@ Compare `update.targetVersionId` to `current_version_id`. Only one of three poss
 
 This step confirms that an update with a lower-than-expected `targetVersionId` is a true duplicate.
 
+Raise an [`INVALID_DID_UPDATE`] error if `update.targetVersionId` is less than `2`.
+
 Create `unsigned_update` by removing the `proof` property from `update`. Hash `unsigned_update` with the [JSON Document Hashing] algorithm and compare it to `update_hash_history[update.targetVersionId - 2]`. Raise a [`LATE_PUBLISHING`] error if the hashes differ.
 
 


### PR DESCRIPTION
Moves the `current_version_id` increment out of the "Process updates Array" loop and into "Apply update", so duplicates confirmed via "Confirm Duplicate Update" no longer advance the counter. This keeps `current_version_id` in lockstep with `update_hash_history` (fixes the inflated `versionId` and the false `LATE_PUBLISHING` on histories like [v2, v2-again, v3]).
  
Also adds the guard discussed in the issue thread: "Confirm Duplicate Update" now raises `INVALID_DID_UPDATE` when `targetVersionId < 2`, so a non-conforming update can't reach the history lookup with a negative index and all resolvers reject it the same way.
  
Fixes #321