### PR TITLE
Require a minimum confirmation count for beacon transactions

### DIFF
--- a/src/data-structures.md
+++ b/src/data-structures.md
@@ -283,6 +283,7 @@ Resolution options MAY contain the following properties:
 
 - `versionId`: OPTIONAL ASCII string representation of the specific version of a DID document to be resolved.
 - `versionTime`: OPTIONAL XML Datetime normalized to UTC without sub-second decimal precision. The DID document to be resolved is the most recent version of the DID document that was valid for the DID before the specified `versionTime`.
+- `minConf`: OPTIONAL positive integer (minimum `1`). The minimum number of Bitcoin block confirmations a [Beacon Signal] transaction requires to count towards resolution. Defaults to `6`.
 - `sidecar`: [Sidecar Data (data structure)].
 
 {% set hide_text = `` %}

--- a/src/data-structures.md
+++ b/src/data-structures.md
@@ -283,7 +283,7 @@ Resolution options MAY contain the following properties:
 
 - `versionId`: OPTIONAL ASCII string representation of the specific version of a DID document to be resolved.
 - `versionTime`: OPTIONAL XML Datetime normalized to UTC without sub-second decimal precision. The DID document to be resolved is the most recent version of the DID document that was valid for the DID before the specified `versionTime`.
-- `minConf`: OPTIONAL positive integer (minimum `1`). The minimum number of Bitcoin block confirmations a [Beacon Signal] transaction requires to count towards resolution. Defaults to `6`.
+- `minConf`: OPTIONAL positive integer (minimum `1`). The minimum number of Bitcoin block confirmations required on a [Beacon Signal] transaction during resolution. Defaults to `6`.
 - `sidecar`: [Sidecar Data (data structure)].
 
 {% set hide_text = `` %}

--- a/src/example-data/resolution-options.json
+++ b/src/example-data/resolution-options.json
@@ -1,6 +1,7 @@
 {
   "versionId": "4",
   "versionTime": "2025-01-05T12:00:00Z",
+  "minConf": 6,
   "sidecar": {
     "@context": "https://btcr2.dev/context/v1",
     "genesisDocument": {

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -118,7 +118,7 @@ Scan the `service` entries in `current_document` ([DID Document (data structure)
 
 Implementations are RECOMMENDED to query an indexed Bitcoin blockchain Remote Procedure Call (RPC) service such as [electrs](https://github.com/romanz/electrs) or [Esplora](https://github.com/Blockstream/esplora). Implementations MAY instead traverse blocks from the genesis block. Cache [Beacon Addresses][Beacon Address] to avoid repeated transaction lookups.
 
-A transaction MUST be included in a Bitcoin block and have at least `resolutionOptions.minConf` confirmations (`6` when not provided) for it to count towards resolution. Unconfirmed mempool transactions MUST NOT be processed. [^2]
+A transaction MUST be included in a Bitcoin block and have at least `resolutionOptions.minConf` confirmations (`6` when not provided). Unconfirmed mempool transactions MUST NOT be processed. [^2]
 
 [^2]: Six confirmations is the widely accepted industry standard for treating a Bitcoin transaction as settled. Resolution requests can raise or lower `minConf` to match their own threat and security model; lowering it increases exposure to Bitcoin block reorganizations, which consumers can evaluate from the returned `confirmations` metadata.
 

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -118,6 +118,10 @@ Scan the `service` entries in `current_document` ([DID Document (data structure)
 
 Implementations are RECOMMENDED to query an indexed Bitcoin blockchain Remote Procedure Call (RPC) service such as [electrs](https://github.com/romanz/electrs) or [Esplora](https://github.com/Blockstream/esplora). Implementations MAY instead traverse blocks from the genesis block. Cache [Beacon Addresses][Beacon Address] to avoid repeated transaction lookups.
 
+A transaction MUST be included in a Bitcoin block and have at least `resolutionOptions.minConf` confirmations (`6` when not provided) for it to count towards resolution. Unconfirmed mempool transactions MUST NOT be processed. [^2]
+
+[^2]: Six confirmations is the widely accepted industry standard for treating a Bitcoin transaction as settled. Resolution requests can raise or lower `minConf` to match their own threat and security model; lowering it increases exposure to Bitcoin block reorganizations, which consumers can evaluate from the returned `confirmations` metadata.
+
 For each transaction found:
 
 * Derive `update_hash` from the transaction's [Signal Bytes] based on the [Beacon Type]:


### PR DESCRIPTION
Adds the confirmation rule discussed in the issue: a beacon transaction MUST be included in a Bitcoin block and have at least resolutionOptions.minConf confirmations (default 6) to count towards resolution. minConf is floored at 1: mempool contents are node-local, unordered, and replaceable (RBF), so unconfirmed transactions never count regardless of options. A footnote explains that 6 is the broadly accepted settlement standard and that lowering minConf trades reorg exposure, which consumers can evaluate from the REQUIRED confirmations metadata. The Resolution Options data structure and example gain the new minConf property.

Closes #37 