### PR TITLE
Update DID Resolution abstract

### DIFF
--- a/src/references.bib
+++ b/src/references.bib
@@ -106,9 +106,7 @@ This document specifies the DID syntax, a common data model, core properties, se
   year = {2026},
   url = {https://www.w3.org/TR/2026/CR-did-resolution-1.0-20260806/},
   note = {DID-RESOLUTION},
-  abstract = {Decentralized identifiers (DIDs) are a new type of identifier for verifiable, "self-sovereign" digital identity. DIDs are fully under the control of the DID controller, independent from any centralized registry, identity provider, or certificate authority. DIDs resolve to DID Documents — simple documents that describe how to use that specific DID.
-
-This document specifies the algorithms and guidelines for resolving DIDs and dereferencing DID URLs. Additionally, this document describes the input and output metadata related to the DID resolution processes and further describes the data structures that may be returned from a DID resolution request. This document relies on the core DID specification, Decentralized Identifiers (DIDs) v1.1, which describes the underlying DID architecture in full detail.}
+  abstract = {Decentralized identifier (DID) resolution is the process of obtaining a DID document and accompanying metadata for a specific DID. The process takes a DID and a set of resolution options as its input and returns a DID document and associated metadata about the resolved document and the resolution request. A resolved DID document is a set of information which enables cryptographically verifiable interactions with the DID subject, including mechanisms such as cryptographic public keys. This specification covers the algorithms and guidelines to be used for DID resolution and relies on the core DID specification, Decentralized Identifiers (DIDs) v1.0, which describes the underlying DID architecture in full detail.}
 }
 
 @misc{ECMA-262,


### PR DESCRIPTION
We recently updated our reference to the DID Resolution spec from the draft 0.3 to the latest CR v1. This PR updates the abstract text to match.

Interestingly, the updated abstract says the DID Resolution spec relies on DID core **v1.0**, while the
abstract in the 0.3 document said **v1.1**.

