### PR TITLE
Update semantics: single RFC 6902 patch document, patch-failure error, `targetVersionId` referent

### DIFF
--- a/src/data-structures.md
+++ b/src/data-structures.md
@@ -103,8 +103,12 @@ SHA-256 hashes {{#cite SHA256}} (`targetHash` and `sourceHash`) MUST be produced
   operation objects, that defines a set of transformations to be applied to a DID document. The
   result of applying the patch MUST be a conformant DID document according to the DID core v1.1
   specification {{#cite DID-CORE}}.
-- `targetVersionId`: The `versionId` of the DID document after the patch has been applied. The
-  targetVersionId MUST be one more than the `versionId` of the DID document being updated.
+- `targetVersionId`: The version of the DID document after the patch has been applied, i.e., the
+  `versionId` that will be returned in the [DID document metadata (data structure)] once this
+  update is applied. The `targetVersionId` MUST be one more than the integer form of the
+  `versionId` returned in the [DID document metadata (data structure)] before this update is
+  applied. `versionId` is never a property of the DID document itself, so this requirement
+  cannot be checked when the update is constructed; it is enforced at resolution time.
 - `sourceHash`: SHA-256 hash of the DID document that the patch MUST be applied to. The hash MUST be produced by the [JSON Document Hashing] algorithm.
 - `targetHash`: SHA-256 hash of the DID document that results from applying the patch to the source document. The hash MUST be produced by the [JSON Document Hashing] algorithm.
 

--- a/src/data-structures.md
+++ b/src/data-structures.md
@@ -104,10 +104,10 @@ SHA-256 hashes {{#cite SHA256}} (`targetHash` and `sourceHash`) MUST be produced
   result of applying the patch MUST be a conformant DID document according to the DID core v1.1
   specification {{#cite DID-CORE}}.
 - `targetVersionId`: The version of the DID document that results from applying the patch, i.e., the
-`versionId` that will be returned in the [DID document metadata (data structure)] for the updated DID 
-document. The `targetVersionId` MUST be one more than the integer form of the `versionId` of the DID 
-document being updated. `versionId` is never a property of the DID document itself, so this requirement 
-cannot be checked when the update is constructed; it is enforced at resolution time.
+  `versionId` that will be returned in the [DID document metadata (data structure)] for the updated DID 
+  document. The `targetVersionId` MUST be one more than the integer form of the `versionId` of the DID 
+  document being updated. `versionId` is never a property of the DID document itself, so this requirement 
+  cannot be checked when the update is constructed; it is enforced at resolution time.
 - `sourceHash`: SHA-256 hash of the DID document that the patch MUST be applied to. The hash MUST be produced by the [JSON Document Hashing] algorithm.
 - `targetHash`: SHA-256 hash of the DID document that results from applying the patch to the source document. The hash MUST be produced by the [JSON Document Hashing] algorithm.
 

--- a/src/data-structures.md
+++ b/src/data-structures.md
@@ -99,9 +99,10 @@ SHA-256 hashes {{#cite SHA256}} (`targetHash` and `sourceHash`) MUST be produced
   - `"https://w3id.org/security/data-integrity/v2"`
   - `"https://w3id.org/json-ld-patch/v1"`
   - `"https://btcr2.dev/context/v1"`
-- `patch`: A JSON Patch {{#cite RFC6902}} object that defines a set of transformations to be
-  applied to a DID document. The result of applying the patch MUST be a conformant DID document
-  according to the DID core v1.1 specification {{#cite DID-CORE}}.
+- `patch`: A single JSON Patch {{#cite RFC6902}} document, i.e., one flat array of JSON Patch
+  operation objects, that defines a set of transformations to be applied to a DID document. The
+  result of applying the patch MUST be a conformant DID document according to the DID core v1.1
+  specification {{#cite DID-CORE}}.
 - `targetVersionId`: The `versionId` of the DID document after the patch has been applied. The
   targetVersionId MUST be one more than the `versionId` of the DID document being updated.
 - `sourceHash`: SHA-256 hash of the DID document that the patch MUST be applied to. The hash MUST be produced by the [JSON Document Hashing] algorithm.

--- a/src/data-structures.md
+++ b/src/data-structures.md
@@ -103,12 +103,11 @@ SHA-256 hashes {{#cite SHA256}} (`targetHash` and `sourceHash`) MUST be produced
   operation objects, that defines a set of transformations to be applied to a DID document. The
   result of applying the patch MUST be a conformant DID document according to the DID core v1.1
   specification {{#cite DID-CORE}}.
-- `targetVersionId`: The version of the DID document after the patch has been applied, i.e., the
-  `versionId` that will be returned in the [DID document metadata (data structure)] once this
-  update is applied. The `targetVersionId` MUST be one more than the integer form of the
-  `versionId` returned in the [DID document metadata (data structure)] before this update is
-  applied. `versionId` is never a property of the DID document itself, so this requirement
-  cannot be checked when the update is constructed; it is enforced at resolution time.
+- `targetVersionId`: The version of the DID document that results from applying the patch, i.e., the
+`versionId` that will be returned in the [DID document metadata (data structure)] for the updated DID 
+document. The `targetVersionId` MUST be one more than the integer form of the `versionId` of the DID 
+document being updated. `versionId` is never a property of the DID document itself, so this requirement 
+cannot be checked when the update is constructed; it is enforced at resolution time.
 - `sourceHash`: SHA-256 hash of the DID document that the patch MUST be applied to. The hash MUST be produced by the [JSON Document Hashing] algorithm.
 - `targetHash`: SHA-256 hash of the DID document that results from applying the patch to the source document. The hash MUST be produced by the [JSON Document Hashing] algorithm.
 

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -187,7 +187,7 @@ Hash `current_document` with the [JSON Document Hashing] algorithm. Raise an [`I
 
 [Check `update.proof`](#check-update-proof).
 
-Apply the `update.patch` JSON Patch {{#cite RFC6902}} to `current_document`.
+Apply the `update.patch` JSON Patch {{#cite RFC6902}} to `current_document`. Raise an [`INVALID_DID_UPDATE`] error if `update.patch` is malformed or fails to apply. JSON Patch operations are evaluated in order; the first operation that fails, including a failed `test` operation, fails the whole patch.
 
 Verify that `current_document` conforms to DID Core v1.1 {{#cite DID-CORE}} and that `current_document.id` equals `did`. Otherwise raise [`INVALID_DID_UPDATE`].
 

--- a/src/operations/update.md
+++ b/src/operations/update.md
@@ -15,7 +15,7 @@ The update operation has the following function signature:
 ```rust
 fn update(
   didSourceDocument,
-  jsonPatches,
+  jsonPatch,
   targetVersionId,
   verificationMethodId,
   privateKey,
@@ -26,7 +26,7 @@ fn update(
 Input arguments:
 
 - `didSourceDocument`: The source DID document.
-- `jsonPatches`: An array of JSON patch documents {{#cite RFC6902}} with the changes to be made to the source DID document.
+- `jsonPatch`: A single JSON Patch document {{#cite RFC6902}} with the changes to be made to the source DID document. Its wire shape is defined by the `patch` property of the [BTCR2 Unsigned Update (data structure)].
 - `targetVersionId`: The `versionId` of the target DID document that the new [BTCR2 Signed Update] will yield.
 - `verificationMethodId`: The `verificationMethod` ID used for signing the [BTCR2 Update].
 - `privateKey`: Private key associated with the `verificationMethodId`.
@@ -48,11 +48,11 @@ Constructing a [BTCR2 Signed Update] is a two-step process. First, a [BTCR2 Unsi
 
 This process constructs a [BTCR2 Unsigned Update (data structure)].
 
-Apply all JSON patches in `jsonPatches` to `didSourceDocument` to create `didTargetDocument`. `didTargetDocument` MUST be conformant to DID Core v1.1 {{#cite DID-CORE}}. An [`INVALID_DID_UPDATE`] error MUST be raised if `didTargetDocument.id` is not equal to `didSourceDocument.id`.
+Apply `jsonPatch` to `didSourceDocument` to create `didTargetDocument`. `didTargetDocument` MUST be conformant to DID Core v1.1 {{#cite DID-CORE}}. An [`INVALID_DID_UPDATE`] error MUST be raised if `didTargetDocument.id` is not equal to `didSourceDocument.id`.
 
 Fill the [BTCR2 Unsigned Update (data structure)] template below with the required template variables.
 
-* `array-of-patches`: `jsonPatches` serialized to a JSON string.
+* `array-of-patches`: `jsonPatch` embedded as JSON.
 * `source-hash`: `didSourceDocument` hashed with the [JSON Document Hashing] algorithm.
 * `target-hash`: `didTargetDocument` hashed with the [JSON Document Hashing] algorithm.
 * `target-version-id`: The value of `targetVersionId`.

--- a/src/operations/update.md
+++ b/src/operations/update.md
@@ -27,7 +27,7 @@ Input arguments:
 
 - `didSourceDocument`: The source DID document.
 - `jsonPatch`: A single JSON Patch document {{#cite RFC6902}} with the changes to be made to the source DID document. Its wire shape is defined by the `patch` property of the [BTCR2 Unsigned Update (data structure)].
-- `targetVersionId`: The `versionId` of the target DID document that the new [BTCR2 Signed Update] will yield.
+- `targetVersionId`: The `versionId` that will be returned in the [DID document metadata (data structure)] once the new [BTCR2 Signed Update] is applied.
 - `verificationMethodId`: The `verificationMethod` ID used for signing the [BTCR2 Update].
 - `privateKey`: Private key associated with the `verificationMethodId`.
   - An implementation MAY use the `verificationMethodId` ID to retrieve the private key from a key material manager.
@@ -56,6 +56,8 @@ Fill the [BTCR2 Unsigned Update (data structure)] template below with the requir
 * `source-hash`: `didSourceDocument` hashed with the [JSON Document Hashing] algorithm.
 * `target-hash`: `didTargetDocument` hashed with the [JSON Document Hashing] algorithm.
 * `target-version-id`: The value of `targetVersionId`.
+
+`targetVersionId` MUST be derived from the `versionId` returned in the [DID document metadata (data structure)] by a fresh resolution of the DID, rather than from a locally maintained count. Announcing a [BTCR2 Signed Update] whose `targetVersionId` is wrong in either direction can permanently prevent the DID from resolving.
 
 {% set hide_text = `` %}
 {% set btcr2_unsigned_update_template =

--- a/src/operations/update.md
+++ b/src/operations/update.md
@@ -48,7 +48,7 @@ Constructing a [BTCR2 Signed Update] is a two-step process. First, a [BTCR2 Unsi
 
 This process constructs a [BTCR2 Unsigned Update (data structure)].
 
-Apply `jsonPatch` to `didSourceDocument` to create `didTargetDocument`. `didTargetDocument` MUST be conformant to DID Core v1.1 {{#cite DID-CORE}}. An [`INVALID_DID_UPDATE`] error MUST be raised if `didTargetDocument.id` is not equal to `didSourceDocument.id`.
+Apply `jsonPatch` to `didSourceDocument` to create `didTargetDocument`. An [`INVALID_DID_UPDATE`] error MUST be raised if `jsonPatch` is malformed or fails to apply. JSON Patch {{#cite RFC6902}} operations are evaluated in order; the first operation that fails, including a failed `test` operation, fails the whole patch. `didTargetDocument` MUST be conformant to DID Core v1.1 {{#cite DID-CORE}}. An [`INVALID_DID_UPDATE`] error MUST be raised if `didTargetDocument.id` is not equal to `didSourceDocument.id`.
 
 Fill the [BTCR2 Unsigned Update (data structure)] template below with the required template variables.
 

--- a/src/terminology.md
+++ b/src/terminology.md
@@ -71,7 +71,7 @@ DID. It MUST be either a [Singleton Beacon], [SMT Beacon], or a [CAS Beacon].
 ## BTCR2 Update { #btcr2-update }
 
 A data structure used for transforming a source DID document into a target DID document. It contains
-a JSON Patch {{#cite RFC6902}} object, a version number for the target DID document, and SHA-256
+a JSON Patch {{#cite RFC6902}} document, a version number for the target DID document, and SHA-256
 hashes for the source and target DID documents.
 
 ## BTCR2 Unsigned Update { #btcr2-unsigned-update }


### PR DESCRIPTION
One commit per issue. All three land in the same few lines of the update path, so bundling them is one review pass instead of three rebases.

- **#322**: the wire shape is now stated once, in Data Structures: `patch` is a single RFC 6902 patch document, one flat array of operation objects. `update()`'s input is renamed `jsonPatches` to `jsonPatch` to match, the patch is embedded in the template as JSON rather than "serialized to a JSON string", and the terminology entry drops the stray "object". The `{{array-of-patches}}` template variable name is left alone; renaming it would be cosmetic churn. All shipped implementations already read the patch this way, so nothing breaks.
- **#220**: a malformed patch or a failed operation (including a failed `test`) now raises `INVALID_DID_UPDATE`, per the thread. Defined at both places a patch is applied: `update()` construction and the resolve path's Apply `update` step, since an announced update is untrusted input there.
- **#334**: the old MUST said `targetVersionId` is "one more than the `versionId` of the DID document being updated", but DID documents carry no `versionId`; version is reported in DID Document Metadata. The rule now names its referent and states that it is enforced at resolution time. Deriving the value is part of the update process, so it gets its own normative paragraph in Construct BTCR2 Unsigned Update: take it from a fresh resolution rather than a locally maintained count, because announcing a wrong value in either direction can permanently prevent the DID from resolving. `update()`'s input list keeps only the definition.

Fixes #322
Fixes #220
Fixes #334
