### PR TITLE
Tweak normative references

### DIFF
--- a/src/conformance.md
+++ b/src/conformance.md
@@ -12,3 +12,5 @@ The key words MAY, MUST, MUST NOT, RECOMMENDED, SHOULD, and SHOULD NOT in this d
 Interoperability of implementations of the **did:btcr2** DID method is tested by evaluating an implementation's ability to create, resolve, update, and deactivate, **did:btcr2** identifiers and DID documents that conform to this specification. Interoperability for producers and consumers of **did:btcr2** identifiers and DID documents is provided by ensuring the DIDs and DID documents conform.
 
 Implementations MUST be conformant to all normative statements in Decentralized Identifiers v1.1 {{#cite DID-CORE}} and DID Resolution v1 {{#cite DID-RESOLUTION}}.
+
+DID Resolution v1 normatively references Decentralized Identifiers v1.0. Where a normative statement in DID Resolution v1 relies on Decentralized Identifiers v1.0, the corresponding statement in Decentralized Identifiers v1.1 applies to **did:btcr2** identifiers and DID documents.

--- a/src/includes/errors-links.tera
+++ b/src/includes/errors-links.tera
@@ -1,4 +1,4 @@
-[`INVALID_DID`]: https://www.w3.org/TR/2026/CR-did-resolution-1.0-20260806/#errors
+[`INVALID_DID`]: https://www.w3.org/TR/did-resolution-1.0/#errors
 [`INVALID_DID_UPDATE`]: {{ root }}errors.md#invalid_did_update
 [`LATE_PUBLISHING`]: {{ root }}errors.md#late_publishing
 [`MISSING_UPDATE_DATA`]: {{ root }}errors.md#missing_update_data

--- a/src/references.bib
+++ b/src/references.bib
@@ -99,8 +99,8 @@
   title = {Decentralized Identifiers (DIDs) v1.1},
   author = {Manu Sporny, Dave Longley, Markus Sabadello, Drummond Reed, Orie Steele, Christopher Allen},
   howpublished = {Online},
-  year = {2025},
-  month = {September},
+  year = {2026},
+  month = {March},
   url = {https://www.w3.org/TR/did-1.1/},
   note = {DID-CORE},
   abstract = {Decentralized identifiers (DIDs) are a new type of identifier that enables verifiable, decentralized digital identity. A DID refers to any subject (e.g., a person, organization, thing, data model, abstract entity, etc.) as determined by the controller of the DID. In contrast to typical, federated identifiers, DIDs have been designed so that they may be decoupled from centralized registries, identity providers, and certificate authorities. Specifically, while other parties might be used to help enable the discovery of information related to a DID, the design enables the controller of a DID to prove control over it without requiring permission from any other party. DIDs are URIs that associate a DID subject with a DID document allowing trustable interactions associated with that subject.
@@ -113,9 +113,10 @@ This document specifies the DID syntax, a common data model, core properties, se
 @misc{DID-RESOLUTION,
   title = {Decentralized Identifier Resolution (DID Resolution) v1},
   author = {Stephen Curran, Joe Andrieu},
-  howpublished = {W3C Candidate Recommendation Snapshot, 06 August 2026},
+  howpublished = {Online},
   year = {2026},
-  url = {https://www.w3.org/TR/2026/CR-did-resolution-1.0-20260806/},
+  month = {August},
+  url = {https://www.w3.org/TR/did-resolution-1.0/},
   note = {DID-RESOLUTION},
   abstract = {Decentralized identifier (DID) resolution is the process of obtaining a DID document and accompanying metadata for a specific DID. The process takes a DID and a set of resolution options as its input and returns a DID document and associated metadata about the resolved document and the resolution request. A resolved DID document is a set of information which enables cryptographically verifiable interactions with the DID subject, including mechanisms such as cryptographic public keys. This specification covers the algorithms and guidelines to be used for DID resolution and relies on the core DID specification, Decentralized Identifiers (DIDs) v1.0, which describes the underlying DID architecture in full detail.}
 }


### PR DESCRIPTION
Updates references for DID core and DID resolution specs. Also adds a statement regarding our temporary dependency on both 1.0 and 1.1 versions of DID core spec.

Fixes #348 and #349 
