### PR TITLE
Cite Controlled Identifiers under its own key

### DIFF
--- a/src/data-structures.md
+++ b/src/data-structures.md
@@ -196,7 +196,7 @@ A [Data Integrity Proof] with the `proofPurpose` set to `"capabilityInvocation"`
 
 This data structure is a Map data structure with the same properties as [Data Integrity Config (data structure)] and one additional property:
 
-- `proofValue`: MUST be a detached Schnorr signature produced according to Schnorr Signatures for secp256k1 {{#cite BIP340}}, as a Multibase `"base-58-btc"` {{#cite CID}} encoded string.
+- `proofValue`: MUST be a detached Schnorr signature produced according to Schnorr Signatures for secp256k1 {{#cite BIP340}}, as a Multibase `"base-58-btc"` {{#cite CONTROLLED-IDENTIFIERS}} encoded string.
 
 {% set hide_text = `` %}
 {% set ex_di_proof =

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -87,7 +87,7 @@ Process the [Genesis Document] provided in `sidecar.genesisDocument` by replacin
 Render the [Initial DID Document] template with these values (Bitcoin addresses MUST use the Bitcoin URI Scheme {{#cite BIP321}}):
 
 * `did`: The `did`.
-* `public-key-multikey`: Public key as a Multibase `"base-58-btc"` {{#cite CID}} encoded string.
+* `public-key-multikey`: Public key as a Multibase `"base-58-btc"` {{#cite CONTROLLED-IDENTIFIERS}} encoded string.
 * `p2pkh-bitcoin-address`: Pay-to-Public-Key-Hash (P2PKH) Bitcoin address produced from the public key.
 * `p2wpkh-bitcoin-address`: Pay-to-Witness-Public-Key-Hash (P2WPKH) Bitcoin address produced from the public key.
 * `p2tr-bitcoin-address`: Pay-to-Taproot (P2TR) Bitcoin address produced from the public key.

--- a/src/references.bib
+++ b/src/references.bib
@@ -84,14 +84,14 @@
   abstract = {This document defines an improved variant of Bech32 called Bech32m, and amends BIP173 to use Bech32m for native segregated witness outputs of version 1 and later. Bech32 remains in use for segregated witness outputs of version 0.}
 }
 
-@misc{CID,
+@misc{CONTROLLED-IDENTIFIERS,
   title = {Controlled Identifiers v1.0},
   author = {Dave Longley, Manu Sporny, Markus Sabadello, Drummond Reed, Orie Steele, Christopher Allen},
   howpublished = {Online},
   year = {2025},
   month = {May},
   url = {https://www.w3.org/TR/cid-1.0/},
-  note = {CID},
+  note = {CONTROLLED-IDENTIFIERS},
   abstract = {A controlled identifier document contains cryptographic material and lists service endpoints for the purposes of verifying cryptographic proofs from, and interacting with, the controller of an identifier.}
 }
 


### PR DESCRIPTION
"CID" meant two unrelated things, told apart only by markup: the bibliography key resolved to Controlled Identifiers v1.0, the terminology link to Content Identifier.

Content Identifier keeps the short form, being the sense this specification uses far more. This does diverge from DID Core, which cites the same document as CID.